### PR TITLE
Review bed leveling calibration

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8096,10 +8096,12 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	SERIAL_PROTOCOLPGM("planeMean.z: ");
 	SERIAL_PROTOCOLLN(planeMean.z);
 
+  //Message below its what the embedded needs to parse with a Regex
+
 	SERIAL_PROTOCOLPGM("ScrewBed0: ");
-	SERIAL_PROTOCOL(Z_knob_left);
-	SERIAL_PROTOCOLPGM("ScrewBed1: ");
-	SERIAL_PROTOCOLLN(Z_knob_right);
+	SERIAL_PROTOCOL(Z_knob_left-Z_knob_back);
+	SERIAL_PROTOCOLPGM(" ScrewBed1: ");
+	SERIAL_PROTOCOLLN(Z_knob_right-Z_knob_back);
 }
 
 //inline void gcode_M141() { // Set chamber temperature

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7947,7 +7947,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	// Probe at 3 arbitrary points
 	// probe left extruder
 	
-	SERIAL_PROTOCOLPGM("Zvalue after home:");
+	SERIAL_PROTOCOLPGM("Zvalue after home: ");
 	SERIAL_PROTOCOLLN(current_position[Z_AXIS]);
 
 	setup_for_endstop_or_probe_move();
@@ -8015,8 +8015,6 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	float z2_at_pt_1 = probe_pt(x_probe_right_extr[0], y_probe_right_extr[0], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	
-	
-	
 	current_position[Z_AXIS] = Z_AFTER_PROBING;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(480), 1);
 			
@@ -8031,8 +8029,8 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	matrix_3x3 plan_bed_level_matrix;
 	
 	plan_bed_level_matrix.set_to_identity();
-	
-	
+
+	// *************** CALCULATE PLANES ***************
 	// Store 3 points from the first plane (obtained with the left extruder)
 	vector_3 pt1_0 = vector_3(x_probe_left_extr[0], y_probe_left_extr[0], z_at_pt_1);
 	vector_3 pt2_0 = vector_3(x_probe_left_extr[1], y_probe_left_extr[1], z_at_pt_2);
@@ -8047,8 +8045,11 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	planeNormal_0 = vector_3(planeNormal_0.x, planeNormal_0.y, planeNormal_0.z);
 	
 	// Store 3 points from the second plane (obtained with the right extruder)
-	// Take into account the possible offset of the endstops. Consider that points 2 and 3 from the first and second tool respectively are the same
-	float z_variation_endstops = z2_at_pt_3 - z_at_pt_2;
+	// Take into account the possible offset of the endstops.
+	// Because there are two common points, consider the variation as the mean between the two measurements.
+	float z_variation_endstops = ((z2_at_pt_3 - z_at_pt_2) + (z2_at_pt_2 - z_at_pt_3)) / 2.0;
+
+	// Store 3 points from the second plane (obtained with the right extruder)
 	vector_3 pt1_1 = vector_3(x_probe_right_extr[0], y_probe_right_extr[0], z2_at_pt_1 - z_variation_endstops);
 	vector_3 pt2_1 = vector_3(x_probe_right_extr[1], y_probe_right_extr[1], z2_at_pt_2 - z_variation_endstops);
 	vector_3 pt3_1 = vector_3(x_probe_right_extr[2], y_probe_right_extr[2], z2_at_pt_3 - z_variation_endstops);
@@ -8057,21 +8058,22 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	vector_3 from_3_to_1_1 = (pt1_1 - pt3_1);
 	vector_3 from_3_to_2_1 = (pt2_1 - pt3_1);
 	vector_3 planeNormal_1 = vector_3::cross(from_3_to_1_1, from_3_to_2_1); // Point 3 is 2 on the left
+	
 	// Calculate normal vector of the second plane
 	planeNormal_1 = vector_3(planeNormal_1.x, planeNormal_1.y, planeNormal_1.z);
 
 	// Obtain the mean vector
 	// TODO In case the variance is too much, we should consider send a message indicating the surface is not flat enough
-	planeMean = vector_3(planeNormal_0.x + planeNormal_1.x / 2.0, planeNormal_0.y + planeNormal_1.y / 2.0, planeNormal_0.z + planeNormal_1.z / 2.0);
+	vector_3 planeMean = vector_3((planeNormal_0.x + planeNormal_1.x) / 2.0, (planeNormal_0.y + planeNormal_1.y) / 2.0, (planeNormal_0.z + planeNormal_1.z) / 2.0);
 
 	// Calculate base point (Z=0) of this plane by considering that the Z axis starts at the exact point where the fixed knob is located
 	float planeMean_base_point = -(planeMean.x * x_screw_bed_calib_1 + planeMean.y * y_screw_bed_calib_1);
 
 	// We get the height in the fixed knob and the left and right knobs
-	float Z_knob_back = -(planeMean.x * x_screw_bed_calib_1 + planeMean.y * y_screw_bed_calib_1 - planeMean_base_point) / planeMean.z; // we already know it's Z = 0 because is the base point
-	assert (Z_knob_back == 0);
-	float Z_knob_left = -(planeMean.x * x_screw_bed_calib_2 + planeMean.y * y_screw_bed_calib_2 - planeMean_base_point) / planeMean.z;
-	float Z_knob_right = -(planeMean.x * x_screw_bed_calib_3 + planeMean.y * y_screw_bed_calib_3 - planeMean_base_point) / planeMean.z;
+	float Z_knob_back = -(planeMean.x * x_screw_bed_calib_1 + planeMean.y * y_screw_bed_calib_1 + planeMean_base_point) / planeMean.z; // we already know it's Z = 0 because is the base point
+	//assert (Z_knob_back == 0);
+	float Z_knob_left = -(planeMean.x * x_screw_bed_calib_2 + planeMean.y * y_screw_bed_calib_2 + planeMean_base_point) / planeMean.z;
+	float Z_knob_right = -(planeMean.x * x_screw_bed_calib_3 + planeMean.y * y_screw_bed_calib_3 + planeMean_base_point) / planeMean.z;
 
 	SERIAL_PROTOCOLPGM("planeNormal_0.x: ");
 	SERIAL_PROTOCOLLN(planeNormal_0.x);
@@ -8090,15 +8092,13 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	SERIAL_PROTOCOLPGM("planeMean.x: ");
 	SERIAL_PROTOCOLLN(planeMean.x);
 	SERIAL_PROTOCOLPGM("planeMean.y: ");
-	SERIAL_PROTOCOLLN(planeNormal_1.y);
+	SERIAL_PROTOCOLLN(planeMean.y);
 	SERIAL_PROTOCOLPGM("planeMean.z: ");
 	SERIAL_PROTOCOLLN(planeMean.z);
-	
-	SERIAL_PROTOCOLPGM("Z_knob_back: ");
-	SERIAL_PROTOCOLLN(Z_knob_back);
-	SERIAL_PROTOCOLPGM("Z_knob_left: ");
-	SERIAL_PROTOCOLLN(Z_knob_left);
-	SERIAL_PROTOCOLPGM("Z_knob_right: ");
+
+	SERIAL_PROTOCOLPGM("ScrewBed0: ");
+	SERIAL_PROTOCOL(Z_knob_left);
+	SERIAL_PROTOCOLPGM("ScrewBed1: ");
 	SERIAL_PROTOCOLLN(Z_knob_right);
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8064,17 +8064,14 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	// TODO In case the variance is too much, we should consider send a message indicating the surface is not flat enough
 	planeMean = vector_3(planeNormal_0.x + planeNormal_1.x / 2.0, planeNormal_0.y + planeNormal_1.y / 2.0, planeNormal_0.z + planeNormal_1.z / 2.0);
 
-	// Calculate base point (Z=0) of this plane by considering that the Z axis starts at the second (2nd) probe position of the left extruder
-	float planeMean_base_point = -(planeMean.x * x_probe_left_extr[1] + planeMean.y * y_probe_left_extr[1])
+	// Calculate base point (Z=0) of this plane by considering that the Z axis starts at the exact point where the fixed knob is located
+	float planeMean_base_point = -(planeMean.x * x_screw_bed_calib_1 + planeMean.y * y_screw_bed_calib_1);
 
 	// We get the height in the fixed knob and the left and right knobs
-	float Z_knob_back = -(planeMean.x * CARGOL_1_X + planeMean.y * CARGOL_1_Y - planeMean_base_point) / planeMean.z;
-	float Z_knob_left = -(planeMean.x * CARGOL_2_X + planeMean.y * CARGOL_2_Y - planeMean_base_point) / planeMean.z;
-	float Z_knob_right = -(planeMean.x * CARGOL_3_X + planeMean.y * CARGOL_3_Y - planeMean_base_point) / planeMean.z;
-
-	// The distance we should move the screws to leave the Z at the same height of the fixed point
-	float distance_knob_left = Z_knob_left - Z_knob_back;
-	float distance_knob_right = Z_knob_right - Z_knob_back;
+	float Z_knob_back = -(planeMean.x * x_screw_bed_calib_1 + planeMean.y * y_screw_bed_calib_1 - planeMean_base_point) / planeMean.z; // we already know it's Z = 0 because is the base point
+	assert (Z_knob_back == 0);
+	float Z_knob_left = -(planeMean.x * x_screw_bed_calib_2 + planeMean.y * y_screw_bed_calib_2 - planeMean_base_point) / planeMean.z;
+	float Z_knob_right = -(planeMean.x * x_screw_bed_calib_3 + planeMean.y * y_screw_bed_calib_3 - planeMean_base_point) / planeMean.z;
 
 	SERIAL_PROTOCOLPGM("planeNormal_0.x: ");
 	SERIAL_PROTOCOLLN(planeNormal_0.x);
@@ -8103,11 +8100,6 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	SERIAL_PROTOCOLLN(Z_knob_left);
 	SERIAL_PROTOCOLPGM("Z_knob_right: ");
 	SERIAL_PROTOCOLLN(Z_knob_right);
-
-	SERIAL_PROTOCOLPGM("distance_knob_left: ");
-	SERIAL_PROTOCOL(distance_knob_left);
-	SERIAL_PROTOCOLPGM("distance_knob_right: ");
-	SERIAL_PROTOCOLLN(distance_knob_right);	
 }
 
 //inline void gcode_M141() { // Set chamber temperature


### PR DESCRIPTION
**Description**
Change a bit the way the bed calibration is done.
Because there are some uncertainties about how the bed calibration behaves, I was trying to simplify the code and adding some comments so this complex procedure can be understood in the future.
I changed the procedure in this way:
- First, calculate the two planes (with left and right end stops), then calculate the mean plane. 
- Then calculate the Z height of the screw that is fixed (at the back of the build plate) and height of points where the left and right screws are placed.
- The distance we should move the thumbscrews is the difference between the current height and the height at the fixed point.

**Benefits**
I try to improve the results of the bed leveling calibration. If not, at least I like to contribute to clean up the code and add some comments to this part.