### PR TITLE
Improved bed calibration procedure

### DIFF
--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC18"
+  #define SHORT_BUILD_VERSION "v0.6.1RC13"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-04-01"
+  #define STRING_DISTRIBUTION_DATE "2020-04-06"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC11"
+  #define SHORT_BUILD_VERSION "v0.6.1RC18"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-03-23"
+  #define STRING_DISTRIBUTION_DATE "2020-04-01"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.
@@ -72,7 +72,7 @@
   /**
    * Defines a generic printer name to be output to the LCD after booting Marlin.
    */
-  #define MACHINE_NAME "BCN3D Epsilon"
+  #define MACHINE_NAME "BCN3D Printer"
 
   /**
    * The SOURCE_CODE_URL is the location where users will find the Marlin Source

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC13"
+  #define SHORT_BUILD_VERSION "v0.6.1RC14"
 		
   /**
    * Verbose version identifier which should contain a reference to the location

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -8,7 +8,7 @@
 
 #define BCN3D_MOD
 
-#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
+//#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
 #ifdef BCN3D_PRINT_SIMULATION
 	#define SIMULATION_TEMP_AMB							22.5
 #endif


### PR DESCRIPTION
Changelog:

- The bed calibration process has been optimized. Now, it proceeds in the following way:

    - First, calculate the two planes (with left and right end stops), then calculate the mean plane.
    - Then calculate the Z height of the screw that is fixed (at the back of the build plate) and height of points where the left and right screws are placed.
    - The distance we should move the thumbscrews is the difference between the current height and the height at the fixed point.