### PR TITLE
Bugfix/print settings

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -891,7 +891,7 @@
 
 // The ASCII buffer for serial input
 #define MAX_CMD_SIZE 96
-#define BUFSIZE 4
+#define BUFSIZE 24
 
 // Transmission to Host Buffer Size
 // To save 386 bytes of PROGMEM (and TX_BUFFER_SIZE+3 bytes of RAM) set to 0.

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -229,7 +229,7 @@ void ok_to_send();
 void kill(const char*);
 
 void quickstop_stepper();
-void dropSeriabuffer();
+void dropSerialbuffer();
 void execPauseFromSerial();
 
 extern uint8_t marlin_debug_flags;
@@ -360,6 +360,8 @@ void dual_mode_z_adjust_raft(void);
 void dual_mode_duplication_extruder_parked(bool skip);
 void dual_mode_mirror_extruder_parked(bool skip);
 void dual_mode_duplication_extruder_parked_purge(void);
+void prioritary_command_detected();
+void end_of_print_detected();
 #endif
 
 void report_current_position();

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC14"
+  #define SHORT_BUILD_VERSION "v0.6.1RC15"
 		
   /**
    * Verbose version identifier which should contain a reference to the location

--- a/Marlin/emergency_parser.cpp
+++ b/Marlin/emergency_parser.cpp
@@ -31,6 +31,7 @@
 #include "emergency_parser.h"
 
 // Static data members
+bool EmergencyParser::has_line_number; // = false
 bool EmergencyParser::killed_by_M112; // = false
 EmergencyParser::State EmergencyParser::state; // = EP_RESET
 


### PR DESCRIPTION
Changelog:

- Priority commands will be detected and executed during the print process.
- Implemented begin and end print commands.
- Now the values of the print settings will be reported after updating them.
- Implemented two new commands (M156/M157) that permit to modify the target temperature values while the printer is busy or printing.
- Changed the Gcode queue length from 4 G-codes to 24 G-codes.