### PR TITLE
[ST-670] Bed calibration when bed is heated

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10250,10 +10250,10 @@ inline void gcode_M109() {
   }
 
   #ifndef MIN_COOLING_SLOPE_DEG_BED
-    #define MIN_COOLING_SLOPE_DEG_BED 1.50
+    #define MIN_COOLING_SLOPE_DEG_BED 0.75
   #endif
   #ifndef MIN_COOLING_SLOPE_TIME_BED
-    #define MIN_COOLING_SLOPE_TIME_BED 60
+    #define MIN_COOLING_SLOPE_TIME_BED 150
   #endif
 
   /**

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.7.0RC6"
+  #define SHORT_BUILD_VERSION "v0.7.0RC7"
 
   /**
    * Verbose version identifier which should contain a reference to the location


### PR DESCRIPTION
Links: https://bcn3d.atlassian.net/browse/ST-670

Changelog:

- Improved bed cooling slope minimum inclination to avoid exiting the wait for temperatures reached loop. This will help to have a better target temperature when it is near the ambient temperature.