### PR TITLE
Release v0.6.1

### DIFF
--- a/CI_CD/Dockerfile
+++ b/CI_CD/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:latest
+
+ENV WORK_DIR /work_dir
+ENV BINARY_NAME arduino-cli
+
+RUN mkdir --parent "${WORK_DIR}"
+WORKDIR "${WORK_DIR}"
+
+RUN apt-get update && apt-get upgrade --yes --quiet && apt-get install --yes --quiet \
+    curl \
+    wget \
+    && \
+    apt-get --yes autoremove && \
+    apt-get --yes autoclean && \
+    apt-get --yes clean
+
+# Install compiler
+RUN curl --silent https://api.github.com/repos/arduino/arduino-cli/releases/latest \
+    | grep browser_download_url \
+    | grep Linux_64 \
+    | cut --delimiter '"' --fields 4 \
+    | wget --quiet --input-file - \
+    && \
+    tar --get --file `ls *.tar.gz` -gzip "${BINARY_NAME}" && \
+    chmod 755 "${BINARY_NAME}" && \
+    mv "${BINARY_NAME}" /usr/local/bin && \
+    rm `ls *.tar.gz`
+
+RUN "${BINARY_NAME}" core update-index && \
+    "${BINARY_NAME}" core install arduino:avr
+
+# Build project
+COPY . "${WORK_DIR}"
+
+RUN "${BINARY_NAME}" compile --fqbn arduino:avr:mega Marlin/Marlin.ino

--- a/CI_CD/Jenkinsfile
+++ b/CI_CD/Jenkinsfile
@@ -1,0 +1,39 @@
+pipeline {
+    agent {
+        kubernetes {}
+    }
+
+    options {
+        timeout(time: 5, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '5'))
+    }
+
+    environment {
+        BINARY_NAME = 'arduino-cli'
+    }
+
+    stages {
+        stage('Install compiler') {
+            steps {
+                sh '''
+                    curl --silent https://api.github.com/repos/arduino/arduino-cli/releases/latest \
+                    | grep browser_download_url \
+                    | grep Linux_64 \
+                    | cut --delimiter '"' --fields 4 \
+                    | wget --quiet --input-file -
+                   '''
+                sh 'tar --get --file `ls *.tar.gz` -gzip "${BINARY_NAME}"'
+                sh 'chmod 755 "${BINARY_NAME}"'
+                sh 'rm `ls *.tar.gz`'
+
+                sh './"${BINARY_NAME}" core update-index'
+                sh './"${BINARY_NAME}" core install arduino:avr'
+            }
+        }
+        stage('Build project') {
+            steps {
+                sh './"${BINARY_NAME}" compile --fqbn arduino:avr:mega Marlin/Marlin.ino'
+            }
+        }
+    }
+}

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -357,33 +357,25 @@
 #define TEMP_BED_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 
 
-//Min temperatures
-_UNUSED static float min_temp_array[6] = {5,5,5,5,5,5};
-
-//Max temperatures
-_UNUSED static float max_temp_array[6] = {300,300,300,300,300,300};
-
-
-
 // The minimal temperature defines the temperature below which the heater will not be enabled It is used
 // to check that the wiring to the thermistor is not broken.
 // Otherwise this would lead to the heater being powered on all the time.
-#define HEATER_0_MINTEMP min_temp_array[0]
-#define HEATER_1_MINTEMP min_temp_array[1]
-#define HEATER_2_MINTEMP min_temp_array[2]
-#define HEATER_3_MINTEMP min_temp_array[3]
-#define HEATER_4_MINTEMP min_temp_array[4]
-#define BED_MINTEMP min_temp_array[5]
+#define HEATER_0_MINTEMP 5
+#define HEATER_1_MINTEMP 5
+#define HEATER_2_MINTEMP 5
+#define HEATER_3_MINTEMP 5
+#define HEATER_4_MINTEMP 5
+#define BED_MINTEMP 5
 
 // When temperature exceeds max temp, your heater will be switched off.
 // This feature exists to protect your hotend from overheating accidentally, but *NOT* from thermistor short/failure!
 // You should use MINTEMP for thermistor short/failure protection.
-#define HEATER_0_MAXTEMP max_temp_array[0]
-#define HEATER_1_MAXTEMP max_temp_array[1]
-#define HEATER_2_MAXTEMP max_temp_array[2]
-#define HEATER_3_MAXTEMP max_temp_array[3]
-#define HEATER_4_MAXTEMP max_temp_array[4]
-#define BED_MAXTEMP max_temp_array[5]
+#define HEATER_0_MAXTEMP 300
+#define HEATER_1_MAXTEMP 300
+#define HEATER_2_MAXTEMP 300
+#define HEATER_3_MAXTEMP 300
+#define HEATER_4_MAXTEMP 300
+#define BED_MAXTEMP 120
 
 //===========================================================================
 //============================= PID Settings ================================
@@ -1192,10 +1184,8 @@ _UNUSED static float max_temp_array[6] = {300,300,300,300,300,300};
 #define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-_UNUSED static float z_safe_homing_x_point = -2.5;
-_UNUSED static float z_safe_homing_y_point = 150;
-  #define Z_SAFE_HOMING_X_POINT z_safe_homing_x_point   // X point for Z homing when homing all axes (G28).
-  #define Z_SAFE_HOMING_Y_POINT z_safe_homing_y_point    // Y point for Z homing when homing all axes (G28).
+  #define Z_SAFE_HOMING_X_POINT -2.5   // X point for Z homing when homing all axes (G28).
+  #define Z_SAFE_HOMING_Y_POINT 150    // Y point for Z homing when homing all axes (G28).
 #endif
 
 // Homing speeds (mm/m)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -45,7 +45,7 @@
 #define BCN3D_PRINTER_IS_EPSILON	040
 
 //#define TEST_TRULLAS
-//#define PROTO_EPSILON
+#define PROTO_EPSILON
 
 #ifndef BCN3D_PRINTER_SETUP
 	#define BCN3D_PRINTER_SETUP BCN3D_PRINTER_IS_EPSILON
@@ -916,12 +916,12 @@
 
 
 #if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_SIGMA
-	static float xBedSize = 210;
-	static float yBedSize = 297;
+__attribute__((unused))	static float xBedSize = 210;
+__attribute__((unused))	static float yBedSize = 297;
 
 #else
-	static float xBedSize = 420;
-	static float yBedSize = 300;
+__attribute__((unused))	static float xBedSize = 420;
+__attribute__((unused))	static float yBedSize = 300;
 #endif
 
 	#define X_BED_SIZE xBedSize
@@ -1052,7 +1052,7 @@
  * Turn on with the command 'M111 S32'.
  * NOTE: Requires a lot of PROGMEM!
  */
-//#define DEBUG_LEVELING_FEATURE
+#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(MESH_BED_LEVELING) || ENABLED(AUTO_BED_LEVELING_BILINEAR) || ENABLED(AUTO_BED_LEVELING_UBL)
   // Gradually reduce leveling correction until a set height is reached,

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -914,13 +914,10 @@
 
 // The size of the print bed
 
-#if BCN3D_MOD
-	#define X_BED_SIZE xBedSize
-	#define Y_BED_SIZE yBedSize
-#else
-	#define X_BED_SIZE 420
-	#define Y_BED_SIZE 300
-#endif
+
+#define X_BED_SIZE 420
+#define Y_BED_SIZE 300
+
 
 
 // Travel limits (mm) after homing, corresponding to endstop positions.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -913,13 +913,19 @@
 // @section machine
 
 // The size of the print bed
+
+
 #if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_SIGMA
-	#define X_BED_SIZE 210
-	#define Y_BED_SIZE 297
+	static float xBedSize = 210;
+	static float yBedSize = 297;
+
 #else
-	#define X_BED_SIZE 420
-	#define Y_BED_SIZE 300
+	static float xBedSize = 420;
+	static float yBedSize = 300;
 #endif
+
+	#define X_BED_SIZE xBedSize
+	#define Y_BED_SIZE yBedSize
 
 
 // Travel limits (mm) after homing, corresponding to endstop positions.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -914,11 +914,13 @@
 
 // The size of the print bed
 
-__attribute__((unused))	static float xBedSize = 420;
-__attribute__((unused))	static float yBedSize = 300;
-
-#define X_BED_SIZE xBedSize
-#define Y_BED_SIZE yBedSize
+#if BCN3D_MOD
+	#define X_BED_SIZE xBedSize
+	#define Y_BED_SIZE yBedSize
+#else
+	#define X_BED_SIZE 420
+	#define Y_BED_SIZE 300
+#endif
 
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
@@ -1030,7 +1032,7 @@ __attribute__((unused))	static float yBedSize = 300;
  * Turn on with the command 'M111 S32'.
  * NOTE: Requires a lot of PROGMEM!
  */
-#define DEBUG_LEVELING_FEATURE
+//#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(MESH_BED_LEVELING) || ENABLED(AUTO_BED_LEVELING_BILINEAR) || ENABLED(AUTO_BED_LEVELING_UBL)
   // Gradually reduce leveling correction until a set height is reached,
@@ -1184,10 +1186,8 @@ __attribute__((unused))	static float yBedSize = 300;
 #define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  //#define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).
-  //#define Z_SAFE_HOMING_Y_POINT ((Y_BED_SIZE) / 2)    // Y point for Z homing when homing all axes (G28).
-__attribute__((unused))  static float z_safe_homing_x_point = -2.5;
-__attribute__((unused))  static float z_safe_homing_y_point = 150;
+_UNUSED static float z_safe_homing_x_point = -2.5;
+_UNUSED static float z_safe_homing_y_point = 150;
   #define Z_SAFE_HOMING_X_POINT z_safe_homing_x_point   // X point for Z homing when homing all axes (G28).
   #define Z_SAFE_HOMING_Y_POINT z_safe_homing_y_point    // Y point for Z homing when homing all axes (G28).
 #endif

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -356,25 +356,34 @@
 #define TEMP_BED_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
 #define TEMP_BED_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 
+
+//Min temperatures
+_UNUSED static float min_temp_array[6] = {5,5,5,5,5,5};
+
+//Max temperatures
+_UNUSED static float max_temp_array[6] = {300,300,300,300,300,300};
+
+
+
 // The minimal temperature defines the temperature below which the heater will not be enabled It is used
 // to check that the wiring to the thermistor is not broken.
 // Otherwise this would lead to the heater being powered on all the time.
-#define HEATER_0_MINTEMP 5
-#define HEATER_1_MINTEMP 5
-#define HEATER_2_MINTEMP 5
-#define HEATER_3_MINTEMP 5
-#define HEATER_4_MINTEMP 5
-#define BED_MINTEMP 5
+#define HEATER_0_MINTEMP min_temp_array[0]
+#define HEATER_1_MINTEMP min_temp_array[1]
+#define HEATER_2_MINTEMP min_temp_array[2]
+#define HEATER_3_MINTEMP min_temp_array[3]
+#define HEATER_4_MINTEMP min_temp_array[4]
+#define BED_MINTEMP min_temp_array[5]
 
 // When temperature exceeds max temp, your heater will be switched off.
 // This feature exists to protect your hotend from overheating accidentally, but *NOT* from thermistor short/failure!
 // You should use MINTEMP for thermistor short/failure protection.
-#define HEATER_0_MAXTEMP 300
-#define HEATER_1_MAXTEMP 300
-#define HEATER_2_MAXTEMP 300
-#define HEATER_3_MAXTEMP 300
-#define HEATER_4_MAXTEMP 300
-#define BED_MAXTEMP 125
+#define HEATER_0_MAXTEMP max_temp_array[0]
+#define HEATER_1_MAXTEMP max_temp_array[1]
+#define HEATER_2_MAXTEMP max_temp_array[2]
+#define HEATER_3_MAXTEMP max_temp_array[3]
+#define HEATER_4_MAXTEMP max_temp_array[4]
+#define BED_MAXTEMP max_temp_array[5]
 
 //===========================================================================
 //============================= PID Settings ================================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -45,7 +45,7 @@
 #define BCN3D_PRINTER_IS_EPSILON	040
 
 //#define TEST_TRULLAS
-#define PROTO_EPSILON
+//#define PROTO_EPSILON
 
 #ifndef BCN3D_PRINTER_SETUP
 	#define BCN3D_PRINTER_SETUP BCN3D_PRINTER_IS_EPSILON
@@ -355,7 +355,6 @@
 #define TEMP_BED_RESIDENCY_TIME 2   // (seconds)
 #define TEMP_BED_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
 #define TEMP_BED_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
-
 
 // The minimal temperature defines the temperature below which the heater will not be enabled It is used
 // to check that the wiring to the thermistor is not broken.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -914,43 +914,21 @@
 
 // The size of the print bed
 
-
-#if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_SIGMA
-__attribute__((unused))	static float xBedSize = 210;
-__attribute__((unused))	static float yBedSize = 297;
-
-#else
 __attribute__((unused))	static float xBedSize = 420;
 __attribute__((unused))	static float yBedSize = 300;
-#endif
 
-	#define X_BED_SIZE xBedSize
-	#define Y_BED_SIZE yBedSize
+#define X_BED_SIZE xBedSize
+#define Y_BED_SIZE yBedSize
 
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
-#if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_SIGMA
-    #define BED_OFFSET_X	 0
-	#define X_MIN_POS		 -47
-#else
-#ifdef PROTO_EPSILON
-	#define BED_OFFSET_X	 0
-#else
-	#define BED_OFFSET_X	 2
-#endif	
-	#define X_MIN_POS		 -51.5 - BED_OFFSET_X
-	//#define X_MIN_POS -51
-#endif
+// Epsilon default values
+#define X_MIN_POS -53.5
 #define Y_MIN_POS -1
 #define Z_MIN_POS 0
 #define X_MAX_POS (X_BED_SIZE + 2) 
 #define Y_MAX_POS Y_BED_SIZE + 1
-#if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_SIGMA
-	#define Z_MAX_POS 210
-#else
-	#define Z_MAX_POS 400//PRO
-#endif
-
+#define Z_MAX_POS 400
 
 /**
  * Software Endstops
@@ -1208,17 +1186,10 @@ __attribute__((unused))	static float yBedSize = 300;
 #if ENABLED(Z_SAFE_HOMING)
   //#define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).
   //#define Z_SAFE_HOMING_Y_POINT ((Y_BED_SIZE) / 2)    // Y point for Z homing when homing all axes (G28).
-  #if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_EPSILON
-	  #ifdef PROTO_EPSILON
-		#define Z_SAFE_HOMING_X_POINT	4.5
-	  #else
-		#define Z_SAFE_HOMING_X_POINT	-4.5 - BED_OFFSET_X   // X point for Z homing when homing all axes (G28).
-	  #endif	  
-	  #define Z_SAFE_HOMING_Y_POINT 150    // Y point for Z homing when homing all axes (G28).
-  #else
-	  #define Z_SAFE_HOMING_X_POINT 4   // X point for Z homing when homing all axes (G28).
-	  #define Z_SAFE_HOMING_Y_POINT 147    // Y point for Z homing when homing all axes (G28). 
-  #endif
+__attribute__((unused))  static float z_safe_homing_x_point = -2.5;
+__attribute__((unused))  static float z_safe_homing_y_point = 150;
+  #define Z_SAFE_HOMING_X_POINT z_safe_homing_x_point   // X point for Z homing when homing all axes (G28).
+  #define Z_SAFE_HOMING_Y_POINT z_safe_homing_y_point    // Y point for Z homing when homing all axes (G28).
 #endif
 
 // Homing speeds (mm/m)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -348,7 +348,7 @@
   //#define X1_MAX_POS X_BED_SIZE // set maximum to ensure first x-carriage doesn't hit the parked second X-carriage
   #define X1_MAX_POS X_MAX_POS // set maximum to ensure first x-carriage doesn't hit the parked second X-carriage
   #define X2_MIN_POS -2    // set minimum to ensure second x-carriage doesn't hit the parked first X-carriage
-  #define X2_MAX_POS (X_BED_SIZE - (X_MIN_POS + BED_OFFSET_X * 2.0))    // set maximum to the distance between toolheads when both heads are homed (523.0 = 53.5  + 420.0 + 49.5)
+  #define X2_MAX_POS (X_BED_SIZE + 49.5)    // set maximum to the distance between toolheads when both heads are homed (523.0 = 53.5  + 420.0 + 49.5)
   #define X2_HOME_DIR 1     // the second X-carriage always homes to the maximum endstop position
   #define X2_HOME_POS X2_MAX_POS // default home position is the maximum carriage position
       // However: In this mode the HOTEND_OFFSET_X value for the second extruder provides a software

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -891,7 +891,7 @@
 
 // The ASCII buffer for serial input
 #define MAX_CMD_SIZE 96
-#define BUFSIZE 4
+#define BUFSIZE 24
 
 // Transmission to Host Buffer Size
 // To save 386 bytes of PROGMEM (and TX_BUFFER_SIZE+3 bytes of RAM) set to 0.

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -239,7 +239,7 @@ extern bool Running;
 inline bool IsRunning() { return  Running; }
 inline bool IsStopped() { return !Running; }
 
-bool enqueue_and_echo_command(const char* cmd);           // Add a single command to the end of the buffer. Return false on failure.
+bool enqueue_and_echo_command(const char* cmd, bool say_ok=false); // Add a single command to the end of the buffer. Return false on failure.
 void enqueue_and_echo_commands_P(const char * const cmd); // Set one or more commands to be prioritized over the next Serial/SD command.
 void clear_command_queue();
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -229,7 +229,7 @@ void ok_to_send();
 void kill(const char*);
 
 void quickstop_stepper();
-void dropSeriabuffer();
+void dropSerialbuffer();
 void execPauseFromSerial();
 
 extern uint8_t marlin_debug_flags;
@@ -360,6 +360,8 @@ void dual_mode_z_adjust_raft(void);
 void dual_mode_duplication_extruder_parked(bool skip);
 void dual_mode_mirror_extruder_parked(bool skip);
 void dual_mode_duplication_extruder_parked_purge(void);
+void prioritary_command_detected();
+void end_of_print_detected();
 #endif
 
 void report_current_position();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -374,11 +374,10 @@
 #endif
 
 #if defined(BCN3D_MOD)
-#include "FRS_Monitoring.h"
-#include "Door_Monitoring.h"
-#include "Leds_handler.h"
-//#include "chamberFanPWM.h"
-#include "printerStats.h"
+  #include "FRS_Monitoring.h"
+  #include "Door_Monitoring.h"
+  #include "Leds_handler.h"
+  #include "printerStats.h"
 #endif
 
 bool Running = true;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9853,6 +9853,7 @@ inline void gcode_M105() {
 
 #endif // FAN_COUNT > 0
 
+
 #if DISABLED(EMERGENCY_PARSER)
 
   /**
@@ -11777,7 +11778,23 @@ inline void gcode_M226() {
 		   SERIAL_ECHOLNPAIR("PURGE_PRINTER_FACTOR: ", purge_printer_factor);
 	   }
    }
-   
+   /*
+	* M305: P#heater or B bed X#IDsensor
+   */
+   inline void gcode_M305() {
+	   if (parser.seen('P') && parser.seen('X')) {
+			uint8_t index = parser.intval('P');
+			uint16_t sensorId = parser.intval('X');
+			if (index < HOTENDS ){
+				thermalManager.update_heater_ttbl_map(index, sensorId);
+			}
+	   }
+	   else if (parser.seen('B') && parser.seen('X')){
+			uint16_t sensorId = parser.intval('X');
+			thermalManager.update_bed_ttbl(sensorId);
+	   }
+   }
+   inline void gcode_M306() {}
    
    
 #if HAS_BUZZER
@@ -14852,7 +14869,8 @@ void process_parsed_command() {
       #if ENABLED(PIDTEMPBED)
         case 304: gcode_M304(); break;                            // M304: Set Bed PID parameters
       #endif
-
+		case 305: gcode_M305(); break;							  // M305: BCN3D_MOD to override temp sensor
+		case 306: gcode_M306(); break;
       #if HAS_MICROSTEPS
         case 350: gcode_M350(); break;                            // M350: Set microstepping mode. Warning: Steps per unit remains unchanged. S code sets stepping mode for all drivers.
         case 351: gcode_M351(); break;                            // M351: Toggle MS1 MS2 pins directly, S# determines MS1 or MS2, X# sets the pin high/low.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1611,7 +1611,7 @@ bool get_target_extruder_from_command(const uint16_t code) {
 			// In Duplication Mode, T0 can move as far left as X_MIN_POS
 			// but not so far to the right that T1 would move past the end
 			soft_endstop_min[X_AXIS] = base_min_pos(X_AXIS);
-			soft_endstop_max[X_AXIS] = base_max_pos(X_AXIS)-(X_BED_SIZE/2)-20;
+			soft_endstop_max[X_AXIS] = base_max_pos(X_AXIS)-(xBedSize/2)-20;
 		}
         else {
           // In other modes, T0 can move from X_MIN_POS to X_MAX_POS
@@ -7473,7 +7473,7 @@ void z_test_print_code(uint8_t tool, float x_offset, float hSize=0.4/*default va
 	current_position[Y_AXIS] = 187.5;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(6000), active_extruder); // move Y
 	
-	current_position[X_AXIS] = x_offset + X1_MIN_POS + X_BED_SIZE/2 + 20.5;
+	current_position[X_AXIS] = x_offset + base_min_pos(X_AXIS) + xBedSize/2 + 20.5;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(7200), active_extruder); // move X (faster)
 	
 	current_position[Z_AXIS] = layer_height;	
@@ -7622,7 +7622,7 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 			//draw borders
 			current_position[Y_AXIS]=275.5;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 100, active_extruder);
-			current_position[X_AXIS] = X1_MIN_POS + X_BED_SIZE/2 + 92.5;//Move X and Z
+			current_position[X_AXIS] = base_min_pos(X_AXIS) + xBedSize/2 + 92.5;//Move X and Z
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 120, active_extruder);
 			current_position[Z_AXIS] = LINES_LAYER_HEIGHT_XY;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 8, active_extruder);
@@ -7685,7 +7685,7 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 	
 	
 
-	current_position[X_AXIS] = X1_MIN_POS + X_BED_SIZE/2 + 92.5;
+	current_position[X_AXIS] = base_min_pos(X_AXIS) + xBedSize/2 + 92.5;
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 120, active_extruder);
 	current_position[Z_AXIS] = LINES_LAYER_HEIGHT_XY;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 100 , active_extruder);
@@ -7785,7 +7785,7 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 		if (i == 0){
 			current_position[Y_AXIS] = 23.5;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 100, active_extruder);
-			current_position[X_AXIS] = X1_MIN_POS + X_BED_SIZE/2 + 4.5;
+			current_position[X_AXIS] = base_min_pos(X_AXIS) + xBedSize/2 + 4.5;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 120, active_extruder);
 			current_position[Z_AXIS] = LINES_LAYER_HEIGHT_XY;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 8, active_extruder);
@@ -7843,7 +7843,7 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 			
 			current_position[Y_AXIS] = 23.5;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 100, active_extruder);
-			current_position[X_AXIS] = X1_MIN_POS + X_BED_SIZE/2 + 4.5;
+			current_position[X_AXIS] = base_min_pos(X_AXIS) + xBedSize/2 + 4.5;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 120, active_extruder);
 			current_position[Z_AXIS] = LINES_LAYER_HEIGHT_XY; //Move X and Z
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 8, active_extruder);
@@ -7937,7 +7937,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	feedrate_mm_s = XY_PROBE_FEEDRATE_MM_S;
 
 	// Move the probe to the starting Y	
-	current_position[Y_AXIS] = Y_SIGMA_PROBE_2_LEFT_EXTR - Y_PROBE_OFFSET_FROM_EXTRUDER;
+	current_position[Y_AXIS] = y_probe_left_extr[2] - Y_PROBE_OFFSET_FROM_EXTRUDER;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], XY_PROBE_FEEDRATE_MM_S, 1);
 
 	setup_for_endstop_or_probe_move();
@@ -7976,7 +7976,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	clean_up_after_endstop_or_probe_move();
 	
 	// Move the probe to the starting X
-	current_position[X_AXIS] = X_SIGMA_PROBE_1_RIGHT_EXTR - X_SIGMA_SECOND_PROBE_OFFSET_FROM_EXTRUDER;
+	current_position[X_AXIS] = x_probe_right_extr[0] - X_SIGMA_SECOND_PROBE_OFFSET_FROM_EXTRUDER;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(4000), 1);
 	
 	setup_for_endstop_or_probe_move();
@@ -8001,13 +8001,13 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	plan_bed_level_matrix.set_to_identity();
 	
 	
-	vector_3 pt1_0 = vector_3(x_probe_left_extr[1], y_probe_left_extr[1], z_at_pt_1);
-	vector_3 pt2_0 = vector_3(x_probe_left_extr[2], y_probe_left_extr[2], z_at_pt_2);
-	vector_3 pt3_0 = vector_3(x_probe_left_extr[3], y_probe_left_extr[3], z_at_pt_3);
+	vector_3 pt1_0 = vector_3(x_probe_left_extr[0], y_probe_left_extr[0], z_at_pt_1);
+	vector_3 pt2_0 = vector_3(x_probe_left_extr[1], y_probe_left_extr[1], z_at_pt_2);
+	vector_3 pt3_0 = vector_3(x_probe_left_extr[2], y_probe_left_extr[2], z_at_pt_3);
 	
-	vector_3 pt1_1 = vector_3(x_probe_right_extr[1], y_probe_right_extr[1], z2_at_pt_1);
-	vector_3 pt2_1 = vector_3(x_probe_right_extr[2], y_probe_right_extr[2], z2_at_pt_2);
-	vector_3 pt3_1 = vector_3(x_probe_right_extr[3], y_probe_right_extr[3], z2_at_pt_3);
+	vector_3 pt1_1 = vector_3(x_probe_right_extr[0], y_probe_right_extr[0], z2_at_pt_1);
+	vector_3 pt2_1 = vector_3(x_probe_right_extr[1], y_probe_right_extr[1], z2_at_pt_2);
+	vector_3 pt3_1 = vector_3(x_probe_right_extr[2], y_probe_right_extr[2], z2_at_pt_3);
 	
 	vector_3 from_2_to_1_0 = (pt1_0 - pt2_0);
 	vector_3 from_2_to_3_0 = (pt3_0 - pt2_0);
@@ -8030,19 +8030,20 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	float z2_1=(-planeNormal_1.x*(CARGOL_2_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_2_Y-x_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
 	float z3_1=(-planeNormal_1.x*(CARGOL_3_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_3_Y-x_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
 	
-	//SERIAL_PROTOCOLPGM("planeNormal_0.x: ");
-	//SERIAL_PROTOCOLLN(planeNormal_0.x);
-	//SERIAL_PROTOCOLPGM("planeNormal_0.y: ");
-	//SERIAL_PROTOCOLLN(planeNormal_0.y);
-	//SERIAL_PROTOCOLPGM("planeNormal_0.z: ");
-	//SERIAL_PROTOCOLLN(planeNormal_0.z);
-	//
-	//SERIAL_PROTOCOLPGM("planeNormal_1.x: ");
-	//SERIAL_PROTOCOLLN(planeNormal_1.x);
-	//SERIAL_PROTOCOLPGM("planeNormal_1.y: ");
-	//SERIAL_PROTOCOLLN(planeNormal_1.y);
-	//SERIAL_PROTOCOLPGM("planeNormal_1.z: ");
-	//SERIAL_PROTOCOLLN(planeNormal_1.z);
+	
+	SERIAL_PROTOCOLPGM("planeNormal_0.x: ");
+	SERIAL_PROTOCOLLN(planeNormal_0.x);
+	SERIAL_PROTOCOLPGM("planeNormal_0.y: ");
+	SERIAL_PROTOCOLLN(planeNormal_0.y);
+	SERIAL_PROTOCOLPGM("planeNormal_0.z: ");
+	SERIAL_PROTOCOLLN(planeNormal_0.z);
+	
+	SERIAL_PROTOCOLPGM("planeNormal_1.x: ");
+	SERIAL_PROTOCOLLN(planeNormal_1.x);
+	SERIAL_PROTOCOLPGM("planeNormal_1.y: ");
+	SERIAL_PROTOCOLLN(planeNormal_1.y);
+	SERIAL_PROTOCOLPGM("planeNormal_1.z: ");
+	SERIAL_PROTOCOLLN(planeNormal_1.z);
 	
 	SERIAL_PROTOCOLPGM("Zscroll_0: ");
 	SERIAL_PROTOCOLLN(Zscroll_0);
@@ -11563,20 +11564,23 @@ inline void gcode_M226() {
 			   const float distanceAxisX = parser.floatval('X');
 			   if (setMinimumTravel){
 				   set_base_min_pos(X_AXIS, distanceAxisX);
+				   if(home_dir(X_AXIS) == -1) set_base_home_pos(X_AXIS, distanceAxisX);
 			   }
 			   else {
 				   set_base_max_pos(X_AXIS, distanceAxisX);
+				   if(home_dir(X_AXIS) == 1) set_base_home_pos(X_AXIS, distanceAxisX);
 			   }
-			   soft_endstop_min[X_AXIS] = base_min_pos(X_AXIS);
-			   soft_endstop_max[X_AXIS] = base_max_pos(X_AXIS);
+			   update_software_endstops(X_AXIS);
 		   }
 		   if (parser.seen('Y')) {
 			   const float distanceAxisY = parser.floatval('Y');
 			   if (setMinimumTravel){
 				   set_base_min_pos(Y_AXIS, distanceAxisY);
+				   if(home_dir(Y_AXIS) == -1) set_base_home_pos(Y_AXIS, distanceAxisY);
 			   }
-			   else {
+			   else {				   
 				   set_base_max_pos(Y_AXIS, distanceAxisY);
+				   if(home_dir(Y_AXIS) == 1) set_base_home_pos(Y_AXIS, distanceAxisY);
 			   }
 			   soft_endstop_min[Y_AXIS] = base_min_pos(Y_AXIS);
 			   soft_endstop_max[Y_AXIS] = base_max_pos(Y_AXIS);
@@ -11585,9 +11589,11 @@ inline void gcode_M226() {
 			   const float distanceAxisZ = parser.floatval('Z');
 			   if (setMinimumTravel){
 				   set_base_min_pos(Z_AXIS, distanceAxisZ);
+				   if(home_dir(Z_AXIS) == -1) set_base_home_pos(Z_AXIS, distanceAxisZ);
 			   }
 			   else {
 				   set_base_max_pos(Z_AXIS, distanceAxisZ);
+				   if(home_dir(Z_AXIS) == 1) set_base_home_pos(Z_AXIS, distanceAxisZ);
 			   }
 			   soft_endstop_min[Z_AXIS] = base_min_pos(Z_AXIS);
 			   soft_endstop_max[Z_AXIS] = base_max_pos(Z_AXIS);
@@ -11601,25 +11607,23 @@ inline void gcode_M226() {
 			SERIAL_ECHOLNPAIR("Max Axis Travel Y: ", base_max_pos(Y_AXIS));
 			SERIAL_ECHOLNPAIR("Min Axis Travel Z: ", base_min_pos(Z_AXIS));
 			SERIAL_ECHOLNPAIR("Max Axis Travel Z: ", base_max_pos(Z_AXIS));
+			SERIAL_ECHOLNPAIR("Home POS X: ", base_home_pos(X_AXIS));
+			SERIAL_ECHOLNPAIR("Home POS Y: ", base_home_pos(Y_AXIS));
+			SERIAL_ECHOLNPAIR("Home POS X: ", base_home_pos(Z_AXIS));
 		}
    }
    /*
 	* M282: Set bed size. X and Y                                                                  
 	*/
    inline void gcode_M282() {
-	   if(parser.seen('X')||parser.seen('Y')){
-		   
-		   if(parser.seen('X')){
-			   xBedSize = parser.floatval('X');
-		   }
-		   if(parser.seen('Y')){
-			   yBedSize = parser.floatval('Y');
-		   }
+	   if(parser.seen('X') && parser.seen('Y')){		   
+			xBedSize = parser.floatval('X');
+			yBedSize = parser.floatval('Y');
 	   }
 	   else{
 		   SERIAL_ECHO_START();
-		   SERIAL_ECHOLNPAIR("Bed Size X: ", X_BED_SIZE);
-		   SERIAL_ECHOLNPAIR("Bed Size Y: ", Y_BED_SIZE);
+		   SERIAL_ECHOLNPAIR("Bed Size X: ", xBedSize);
+		   SERIAL_ECHOLNPAIR("Bed Size Y: ", yBedSize);
 	   }	   
    }
    /*
@@ -14007,7 +14011,7 @@ inline void invalid_extruder_error(const uint8_t e) {
       #endif
 	  #if defined(PARKING_COLLISON_AVOIDANCE)
 	  //BCN3D BED POTENTIAL ISSUE ABOIDADNCE
-	  if(current_position[Z_AXIS] < Z_AFTER_PROBING && current_position[X_AXIS] >= 0 && current_position[X_AXIS] <= X_BED_SIZE) {
+	  if(current_position[Z_AXIS] < Z_AFTER_PROBING && current_position[X_AXIS] >= 0 && current_position[X_AXIS] <= xBedSize) {
 		  if(current_position[Y_AXIS] > PARKING_COLLISON_AVOIDANCE_Y_LOWER && current_position[Y_AXIS] < PARKING_COLLISON_AVOIDANCE_Y_UPPER) {			  
 			  raised_z = current_position[Z_AXIS] + 5;
 			  SERIAL_ECHOLNPAIR("Raise to ", raised_z);
@@ -16305,11 +16309,11 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							Flag_Raft_Dual_Mode_On = true;							
 							planner.synchronize();							
 							dual_mode_z_adjust_raft();
-							destination[X_AXIS] = inactive_extruder_x_pos - destination_X_2 + X1_MIN_POS;
+							destination[X_AXIS] = inactive_extruder_x_pos - destination_X_2 + base_min_pos(X_AXIS);
 							COPY(fanSpeeds_raft,fanSpeeds);
 						}else{
 							dual_mode_z_adjust_raft();
-							destination[X_AXIS] = inactive_extruder_x_pos - destination_X_2 + X1_MIN_POS;							
+							destination[X_AXIS] = inactive_extruder_x_pos - destination_X_2 + base_min_pos(X_AXIS);							
 						}
 					}
 				}

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7904,6 +7904,7 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 	
 	tool_change(0);
 }
+
 inline void gcode_G290(){//BCN3D Bed leveling
 	
 	#ifdef BCN3D_PRINT_SIMULATION
@@ -7954,7 +7955,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	// Probe at 3 arbitrary points
 	// probe left extruder
 	
-	SERIAL_PROTOCOLPGM("Zvalue after home:");
+	SERIAL_PROTOCOLPGM("Zvalue after home: ");
 	SERIAL_PROTOCOLLN(current_position[Z_AXIS]);
 
 	setup_for_endstop_or_probe_move();
@@ -8022,8 +8023,6 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	float z2_at_pt_1 = probe_pt(x_probe_right_extr[0], y_probe_right_extr[0], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	
-	
-	
 	current_position[Z_AXIS] = Z_AFTER_PROBING;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(480), 1);
 			
@@ -8038,52 +8037,52 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	matrix_3x3 plan_bed_level_matrix;
 	
 	plan_bed_level_matrix.set_to_identity();
-	
-	
+
+	// *************** CALCULATE PLANES ***************
+	// Store 3 points from the first plane (obtained with the left extruder)
 	vector_3 pt1_0 = vector_3(x_probe_left_extr[0], y_probe_left_extr[0], z_at_pt_1);
 	vector_3 pt2_0 = vector_3(x_probe_left_extr[1], y_probe_left_extr[1], z_at_pt_2);
 	vector_3 pt3_0 = vector_3(x_probe_left_extr[2], y_probe_left_extr[2], z_at_pt_3);
 	
-	vector_3 pt1_1 = vector_3(x_probe_right_extr[0], y_probe_right_extr[0], z2_at_pt_1);
-	vector_3 pt2_1 = vector_3(x_probe_right_extr[1], y_probe_right_extr[1], z2_at_pt_2);
-	vector_3 pt3_1 = vector_3(x_probe_right_extr[2], y_probe_right_extr[2], z2_at_pt_3);
-	
-  //The main idea is to use directos vectors form the same coords if later we want to merge both planes
-
+	// Calculate 2 vectors of the first plane
 	vector_3 from_2_to_1_0 = (pt1_0 - pt2_0);
 	vector_3 from_2_to_3_0 = (pt3_0 - pt2_0);
 	vector_3 planeNormal_0 = vector_3::cross(from_2_to_1_0, from_2_to_3_0);
-	planeNormal_0 = vector_3(planeNormal_0.x, planeNormal_0.y, planeNormal_0.z); // Common point is left probe point-2
+
+	// Calculate normal vector of the first plane
+	planeNormal_0 = vector_3(planeNormal_0.x, planeNormal_0.y, planeNormal_0.z);
 	
+	// Store 3 points from the second plane (obtained with the right extruder)
+	// Take into account the possible offset of the endstops.
+	// Because there are two common points, consider the variation as the mean between the two measurements.
+	float z_variation_endstops = ((z2_at_pt_3 - z_at_pt_2) + (z2_at_pt_2 - z_at_pt_3)) / 2.0;
+
+	// Store 3 points from the second plane (obtained with the right extruder)
+	vector_3 pt1_1 = vector_3(x_probe_right_extr[0], y_probe_right_extr[0], z2_at_pt_1 - z_variation_endstops);
+	vector_3 pt2_1 = vector_3(x_probe_right_extr[1], y_probe_right_extr[1], z2_at_pt_2 - z_variation_endstops);
+	vector_3 pt3_1 = vector_3(x_probe_right_extr[2], y_probe_right_extr[2], z2_at_pt_3 - z_variation_endstops);
+	
+	// Calculate 2 vectors of the second plane
 	vector_3 from_3_to_1_1 = (pt1_1 - pt3_1);
 	vector_3 from_3_to_2_1 = (pt2_1 - pt3_1);
-	vector_3 planeNormal_1 = vector_3::cross(from_3_to_1_1, from_3_to_2_1); // Watch out! Right point-3 is 2 on the left
+	vector_3 planeNormal_1 = vector_3::cross(from_3_to_1_1, from_3_to_2_1); // Point 3 is 2 on the left
+	
+	// Calculate normal vector of the second plane
 	planeNormal_1 = vector_3(planeNormal_1.x, planeNormal_1.y, planeNormal_1.z);
 
-//  +--------------------------+
-//  |          Zscroll         |
-//  |                          |
-//  |                          |
-//  |           0/0            |
-//  |                          |
-//  |                          |
-//  |  Z2                  Z3  |
-//  +--------------------------+
+	// Obtain the mean vector
+	// TODO In case the variance is too much, we should consider send a message indicating the surface is not flat enough
+	vector_3 planeMean = vector_3((planeNormal_0.x + planeNormal_1.x) / 2.0, (planeNormal_0.y + planeNormal_1.y) / 2.0, (planeNormal_0.z + planeNormal_1.z) / 2.0);
 
+	// Calculate base point (Z=0) of this plane by considering that the Z axis starts at the exact point where the fixed knob is located
+	float planeMean_base_point = -(planeMean.x * x_screw_bed_calib_1 + planeMean.y * y_screw_bed_calib_1);
 
-  //Below, we calculate the fixed screw knob. INDEX 1	
-	float Zscroll_0=(-planeNormal_0.x*(x_screw_bed_calib_1)-planeNormal_0.y*(y_screw_bed_calib_1))/planeNormal_0.z;
-	float Zscroll_1=(-planeNormal_1.x*(x_screw_bed_calib_1)-planeNormal_1.y*(y_screw_bed_calib_1))/planeNormal_1.z;
-	
-	//Below, we calculate the left knob. INDEX 2
-	float z2_0=(-planeNormal_0.x*(x_screw_bed_calib_2)-planeNormal_0.y*(y_screw_bed_calib_2))/planeNormal_0.z;
-	float z2_1=(-planeNormal_1.x*(x_screw_bed_calib_2)-planeNormal_1.y*(y_screw_bed_calib_2))/planeNormal_1.z;
+	// We get the height in the fixed knob and the left and right knobs
+	float Z_knob_back = -(planeMean.x * x_screw_bed_calib_1 + planeMean.y * y_screw_bed_calib_1 + planeMean_base_point) / planeMean.z; // we already know it's Z = 0 because is the base point
+	//assert (Z_knob_back == 0);
+	float Z_knob_left = -(planeMean.x * x_screw_bed_calib_2 + planeMean.y * y_screw_bed_calib_2 + planeMean_base_point) / planeMean.z;
+	float Z_knob_right = -(planeMean.x * x_screw_bed_calib_3 + planeMean.y * y_screw_bed_calib_3 + planeMean_base_point) / planeMean.z;
 
-  //Below, we calculate the right knob. INDEX 3
-  float z3_0=(-planeNormal_0.x*(x_screw_bed_calib_3)-planeNormal_0.y*(y_screw_bed_calib_3))/planeNormal_0.z;
-	float z3_1=(-planeNormal_1.x*(x_screw_bed_calib_3)-planeNormal_1.y*(y_screw_bed_calib_3))/planeNormal_1.z;
-
-	
 	SERIAL_PROTOCOLPGM("planeNormal_0.x: ");
 	SERIAL_PROTOCOLLN(planeNormal_0.x);
 	SERIAL_PROTOCOLPGM("planeNormal_0.y: ");
@@ -8098,52 +8097,21 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	SERIAL_PROTOCOLPGM("planeNormal_1.z: ");
 	SERIAL_PROTOCOLLN(planeNormal_1.z);
 	
-	SERIAL_PROTOCOLPGM("Zscroll_0: ");
-	SERIAL_PROTOCOLLN(Zscroll_0);
-	SERIAL_PROTOCOLPGM("z2_0: ");
-	SERIAL_PROTOCOLLN(z2_0);
-	SERIAL_PROTOCOLPGM("z3_0: ");
-	SERIAL_PROTOCOLLN(z3_0);
-	
-	SERIAL_PROTOCOLPGM("Zscroll_1: ");
-	SERIAL_PROTOCOLLN(Zscroll_1);
-	SERIAL_PROTOCOLPGM("z2_1: ");
-	SERIAL_PROTOCOLLN(z2_1);
-	SERIAL_PROTOCOLPGM("z3_1: ");
-	SERIAL_PROTOCOLLN(z3_1);
+	SERIAL_PROTOCOLPGM("planeMean.x: ");
+	SERIAL_PROTOCOLLN(planeMean.x);
+	SERIAL_PROTOCOLPGM("planeMean.y: ");
+	SERIAL_PROTOCOLLN(planeMean.y);
+	SERIAL_PROTOCOLPGM("planeMean.z: ");
+	SERIAL_PROTOCOLLN(planeMean.z);
 
-
-	//Update zOffset. We have to take into account the 2 different probe offsets
-	//NOT NEEDED because we have to check the bed from the same position. Theorically the offsets between probes is inexistent
-	//Calculate medians
-	///Alejandro
-
-	//float dz2 = z2_0 - (z2_0 - z2_1)/2.0 - (Zscroll_0 - (Zscroll_0 - Zscroll_1)/2.0);
-	//float dz3 = z3_0 - (z3_0 - z3_1)/2.0 - (Zscroll_0 - (Zscroll_0 - Zscroll_1)/2.0);
-	
-	float dz2_1 = (z2_0-Zscroll_0) + (z2_1-Zscroll_1);
-	dz2_1 = dz2_1/2.0;
-	float dz3_1 = (z3_0-Zscroll_0) + (z3_1-Zscroll_1);
-	dz3_1 = dz3_1/2.0;
-	
-	//Voltes cargols
-
-
+  //Message below its what the embedded needs to parse with a Regex
 
 	SERIAL_PROTOCOLPGM("ScrewBed0: ");
-	SERIAL_PROTOCOL(dz2_1);
+	SERIAL_PROTOCOL(Z_knob_left-Z_knob_back);
 	SERIAL_PROTOCOLPGM(" ScrewBed1: ");
-	SERIAL_PROTOCOLLN(dz3_1);
-	
-	//SERIAL_PROTOCOLPGM("ScrewBed0_v2: ");
-	//SERIAL_PROTOCOL(dz2_1);
-	//SERIAL_PROTOCOLPGM(" ScrewBed1_v2: ");
-	//SERIAL_PROTOCOLLN(dz3_1);
-		
-
-
-	
+	SERIAL_PROTOCOLLN(Z_knob_right-Z_knob_back);
 }
+
 //inline void gcode_M141() { // Set chamber temperature
 //	if (parser.seenval('S')) thermalManager.setTargetChamber(parser.value_celsius());
 //	if (parser.seenval('P')) chamberFanPWM.setup(parser.value_ushort());

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11821,6 +11821,33 @@ inline void gcode_M226() {
 				max_temp_array[5]=parser.floatval('X');
 			}
 	   }
+	   else {
+		   SERIAL_ECHO_START();
+		   #if THERMISTORHEATER_0
+		   SERIAL_ECHOLNPAIR("Min temp heater 0: ", min_temp_array[0]);
+		   SERIAL_ECHOLNPAIR("Max temp heater 0: ", max_temp_array[0]);
+		   #endif
+		   #if THERMISTORHEATER_1
+		   SERIAL_ECHOLNPAIR("Min temp heater 1: ", min_temp_array[1]);
+		   SERIAL_ECHOLNPAIR("Max temp heater 1: ", max_temp_array[1]);
+		   #endif
+		   #if THERMISTORHEATER_2
+		   SERIAL_ECHOLNPAIR("Min temp heater 2: ", min_temp_array[2]);
+		   SERIAL_ECHOLNPAIR("Max temp heater 2: ", max_temp_array[2]);
+		   #endif
+		   #if THERMISTORHEATER_3
+		   SERIAL_ECHOLNPAIR("Min temp heater 3: ", min_temp_array[3]);
+		   SERIAL_ECHOLNPAIR("Max temp heater 3: ", max_temp_array[3]);
+		   #endif
+		   #if THERMISTORHEATER_4
+		   SERIAL_ECHOLNPAIR("Min temp heater 4: ", min_temp_array[4]);
+		   SERIAL_ECHOLNPAIR("Max temp heater 4: ", max_temp_array[4]);
+		   #endif
+		   #ifdef THERMISTORBED 
+		   SERIAL_ECHOLNPAIR("Min temp bed: ", min_temp_array[5]);
+		   SERIAL_ECHOLNPAIR("Max temp bed: ", max_temp_array[5]);
+		   #endif
+	   }
    }
    
    

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -377,7 +377,7 @@
 #include "FRS_Monitoring.h"
 #include "Door_Monitoring.h"
 #include "Leds_handler.h"
-#include "chamberFanPWM.h"
+//#include "chamberFanPWM.h"
 #include "printerStats.h"
 #endif
 
@@ -8097,10 +8097,10 @@ inline void gcode_G290(){//BCN3D Bed leveling
 
 	
 }
-inline void gcode_M141() { // Set chamber temperature
-	if (parser.seenval('S')) thermalManager.setTargetChamber(parser.value_celsius());
-	if (parser.seenval('P')) chamberFanPWM.setup(parser.value_ushort());
-}
+//inline void gcode_M141() { // Set chamber temperature
+//	if (parser.seenval('S')) thermalManager.setTargetChamber(parser.value_celsius());
+//	if (parser.seenval('P')) chamberFanPWM.setup(parser.value_ushort());
+//}
 
 inline void gcode_M668() {
 	planner.synchronize();
@@ -11781,6 +11781,19 @@ inline void gcode_M226() {
 	   }
    }
    /*
+	* M288: Set chamber fan On/Off                                                         
+	*/
+   inline void gcode_M288() {
+	   const uint8_t fan_pin = constrain(parser.byteval('S'), 0, 1);
+	   if(fan_pin == 0) {
+	       digitalWrite(CHAMBER_AUTO_FAN_PIN,LOW); // OFF
+	   } else {
+	       digitalWrite(CHAMBER_AUTO_FAN_PIN,HIGH); // ON				
+	   }
+	   SERIAL_ECHO_START();
+	   SERIAL_ECHOLNPAIR("Chamber fan: ", fan_pin);
+   }
+   /*
 	* M305: P#heater or B bed X#IDsensor
    */
    inline void gcode_M305() {
@@ -14870,9 +14883,9 @@ void process_parsed_command() {
         case 190: gcode_M190(); break;                            // M190: Set Bed Temperature. Wait for target.
       #endif
 	  
-	  #if defined(BCN3D_MOD)
-		case 141: gcode_M141(); break;
-	  #endif
+	  //#if defined(BCN3D_MOD)
+		//case 141: gcode_M141(); break;
+	  //#endif
 
       #if FAN_COUNT > 0
         case 106: gcode_M106(); break;                            // M106: Set Fan Speed
@@ -14994,6 +15007,7 @@ void process_parsed_command() {
         case 285: gcode_M285(); break;                            // M285: Set probe position
         case 286: gcode_M286(); break;                            // M286: Collision avoidance bed leveling
         case 287: gcode_M287(); break;                            // M287: Set printing settings
+        case 288: gcode_M288(); break;							              // M288: Set Chamber fan On/Off
       #endif
 
       #if ENABLED(BABYSTEPPING)
@@ -17506,8 +17520,12 @@ void setup() {
 	frs_monitor.setup();
 	door_monitor.setup();
 	leds_handler.setup();
-	chamberFanPWM.setup();
+	//chamberFanPWM.setup();
 	printerStats.reset();
+	// Chamber fan control
+	pinMode(CHAMBER_AUTO_FAN_PIN,OUTPUT);
+	digitalWrite(CHAMBER_AUTO_FAN_PIN,LOW);
+	// Manual Z error probe trigger
 	pinMode(SDA_PIN, OUTPUT);
 	digitalWrite(SDA_PIN, HIGH);
   #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -628,6 +628,7 @@ _UNUSED static float retract_printer_factor = 8;
 _UNUSED static float retract_print_test_factor = 8;
 _UNUSED static float purge_printer_factor = 20;
 
+
 #endif
 
 #if HAS_BED_PROBE
@@ -11793,8 +11794,53 @@ inline void gcode_M226() {
 			uint16_t sensorId = parser.intval('X');
 			thermalManager.update_bed_ttbl(sensorId);
 	   }
+	   else{
+		   thermalManager.report_sensors_names();
+		   SERIAL_ECHO_START();
+		#if  THERMISTORHEATER_0
+			SERIAL_ECHOLNPAIR("Heater 0 sensor: ", sensor_name_heater0);
+		#endif
+		#if  THERMISTORHEATER_1
+			SERIAL_ECHOLNPAIR("Heater 1 sensor: ", sensor_name_heater1);
+		#endif
+		#if  THERMISTORHEATER_2
+			SERIAL_ECHOLNPAIR("Heater 2 sensor: ", sensor_name_heater2);
+		#endif
+		#if  THERMISTORHEATER_3
+			SERIAL_ECHOLNPAIR("Heater 3 sensor: ", sensor_name_heater3);
+		#endif
+		#if  THERMISTORHEATER_4
+			SERIAL_ECHOLNPAIR("Heater 4 sensor: ", sensor_name_heater4);
+		#endif
+		#if  THERMISTORBED
+			SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
+		#endif
+	   }
    }
-   inline void gcode_M306() {}
+   /*
+	* M306: P#heater or B bed X#temperature S# Max or Min 
+    */
+   
+   inline void gcode_M306() {
+	   if (parser.seen('P') && parser.seen('X') && parser.seen('S')){
+			if (parser.intval('P')<HOTENDS){
+				if (!parser.boolval('S')){
+					min_temp_array[parser.intval('P')]=parser.floatval('X');
+				}
+				else {
+					max_temp_array[parser.intval('P')]=parser.floatval('X');
+				}
+			}
+	   }
+	   else if (parser.seen('B') && parser.seen('X') && parser.seen('S')){
+			if (!parser.boolval('S')){
+				min_temp_array[5]=parser.floatval('X');
+			}
+			else {
+				max_temp_array[5]=parser.floatval('X');
+			}
+	   }
+   }
    
    
 #if HAS_BUZZER

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -590,7 +590,12 @@ int16_t fanSpeeds_raft[FAN_COUNT] = { 0 };
 
 static DualXMode dual_x_carriage_mode = DEFAULT_DUAL_X_CARRIAGE_MODE;
 
+DiscardSerialReason discard_serial = DiscardSerialReason::NONE;
 bool waiting_resend_confirmation = false;
+uint8_t pending_priority_commands = 0;
+bool is_ending_print = false;
+bool pause_started = false;
+bool pause_flag = false;
 
 #endif
 
@@ -1102,16 +1107,50 @@ void gcode_line_error(const char* err) {
   serial_count = 0;
 }
 
+#if defined(BCN3D_MOD)
+void priority_command_detected() {
+  if (gcode_LastN > 0 && !pause_started && !pause_flag && !is_ending_print)
+    pending_priority_commands++;
+}
+
+void end_of_print_detected() {
+  is_ending_print = true;
+}
+
+bool is_priority_command(char* const cmd) { 
+  const char command_letter = cmd[0];
+  if (command_letter != 'M') return false;
+
+  const int command_lenght = strlen(cmd);
+  uint8_t i = 0;
+  const uint8_t max_i = command_lenght < 4 ? (command_lenght - 1) : 3;
+  char codenum_str[4] = {0, 0, 0, 0};
+  while (i < max_i) {
+    const char c = cmd[i+1];
+    if (c == ' ')
+      break;
+    codenum_str[i++] = c;
+  }
+  const uint16_t codenum = atoi(codenum_str);
+
+  return codenum == 106 ||
+         codenum == 156 ||
+         codenum == 157 ||
+         codenum == 220 ||
+         codenum == 221 ||
+         codenum == 537;
+}
+
+void execute_priority_command(char * const cmd);
+#endif
+
+//#define NOTIFY_SERIAL_COMMAND_QUEUE_EMPTY
+
 /**
  * Get all commands waiting on the serial port and queue them.
  * Exit when the buffer is full or when no more characters are
  * left on the serial port.
  */
-#if defined(BCN3D_MOD)
-DiscardSerialReason discard_serial = DiscardSerialReason::NONE;
-//#define NOTIFY_SERIAL_COMMAND_QUEUE_EMPTY
-#endif
-
 inline void get_serial_commands() {
   #if defined(BCN3D_MOD)
   static int raft_indicator = 0;
@@ -1138,26 +1177,27 @@ inline void get_serial_commands() {
     }
   #endif
 
+  #if defined(BCN3D_MOD)
+    if(discard_serial != DiscardSerialReason::NONE && !MYSERIAL0.available()) {	   
+      switch(discard_serial) {
+        case DiscardSerialReason::PAUSE:
+          SERIAL_PROTOCOLLNPGM("M669 executed");
+          break;
+        case DiscardSerialReason::CANCEL:
+          SERIAL_PROTOCOLLNPGM("M541 executed");
+          break;
+        default:
+          break;
+      }
+      discard_serial = DiscardSerialReason::NONE;
+    }
+  #endif
+
   /**
    * Loop while serial characters are incoming and the queue is not full
    */
   int c;
-  #if defined(BCN3D_MOD)
-  if(discard_serial != DiscardSerialReason::NONE && !MYSERIAL0.available()) {	   
-	   switch(discard_serial) {
-		   case DiscardSerialReason::PAUSE:
-		   SERIAL_PROTOCOLLNPGM("M669 executed");
-		   break;
-		   case DiscardSerialReason::CANCEL:
-		   SERIAL_PROTOCOLLNPGM("M541 executed");
-		   break;
-		   default:
-		   break;
-	   }
-	   discard_serial = DiscardSerialReason::NONE;
-  }
-  #endif
-  while (commands_in_queue < BUFSIZE && (c = MYSERIAL0.read()) >= 0) {
+  while ((commands_in_queue < BUFSIZE || pending_priority_commands > 0) && (c = MYSERIAL0.read()) >= 0) {
 
     char serial_char = c;
 
@@ -1205,7 +1245,11 @@ inline void get_serial_commands() {
         }
         #endif
 
+        #if defined(BCN3D_MOD)
+        if (gcode_N != gcode_LastN + 1 && !M110 && discard_serial == DiscardSerialReason::NONE)
+        #else
         if (gcode_N != gcode_LastN + 1 && !M110)
+        #endif
           return gcode_line_error(PSTR(MSG_ERR_LINE_NO));
 
         char *apos = strrchr(command, '*');
@@ -1218,7 +1262,9 @@ inline void get_serial_commands() {
         else
           return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM));
 
-        gcode_LastN = gcode_N;
+        #ifndef BCN3D_MOD
+          gcode_LastN = gcode_N;
+        #endif
       }
       #if ENABLED(SDSUPPORT)
         else if (card.saving && strcmp(command, "M29") != 0) // No line number with M29 in Pronterface
@@ -1233,7 +1279,7 @@ inline void get_serial_commands() {
         case DXC_DUPLICATION_MODE_R:
         case DXC_MIRROR_MODE_R:
         {
-          if(raft_indicator){
+          if(commands_in_queue < BUFSIZE && raft_indicator && npos){
             char *strchr_pointer; // just a pointer to find chars in the command string like X, Y, Z, E, etc
             strchr_pointer = strchr(serial_line_buffer, 'Z');
             if(strchr_pointer != NULL){
@@ -1247,7 +1293,7 @@ inline void get_serial_commands() {
                 SERIAL_PROTOCOLPAIR("Last line subs: ", serial_line_buffer);
                 SERIAL_EOL();
                 memset(serial_line_buffer, '\0', sizeof(serial_line_buffer));
-                gcode_LastN = fileraftstart - 1;
+                gcode_N = fileraftstart - 1;
                 sprintf(serial_line_buffer, "G92 E0 Z0 R%d%c", raft_line_counter_g, 0);
               }
             }
@@ -1343,7 +1389,13 @@ inline void get_serial_commands() {
 
       // Add the command to the queue
       #if defined(BCN3D_MOD)
-      if(discard_serial == DiscardSerialReason::NONE)_enqueuecommand(serial_line_buffer, true);
+      if (pending_priority_commands > 0 && is_priority_command(serial_line_buffer)) {
+        execute_priority_command(serial_line_buffer);
+        pending_priority_commands--;
+      } else if (discard_serial == DiscardSerialReason::NONE && commands_in_queue < BUFSIZE) {
+        _enqueuecommand(serial_line_buffer, true);
+        if (npos) gcode_LastN = gcode_N;
+      }
       #else
       _enqueuecommand(serial_line_buffer, true);
       #endif
@@ -7306,9 +7358,12 @@ inline void gcode_G92() {
 
 #endif // MECHADUINO_I2C_COMMANDS
 
+void report_feedrate();
+void report_flow_percentage(const int target_extruder);
+
 #if defined(BCN3D_MOD)
 inline void gcode_G71(){ //GO Park
-	SERIAL_PROTOCOLPAIR("Go park -> feedrate_mm_s is: ", feedrate_mm_s);
+	SERIAL_PROTOCOLLNPAIR("Go park -> feedrate_mm_s is: ", feedrate_mm_s);
 	float saved_x_position = current_position[X_AXIS];
 	planner.synchronize();
 	if(dual_x_carriage_mode ==DXC_DUPLICATION_MODE)	motorMode = motordriver_mode::motordefault;
@@ -7349,12 +7404,12 @@ inline void gcode_G72(){ //GO unPark
 	if(dual_x_carriage_mode == DXC_DUPLICATION_MODE) motorMode = motordriver_mode::motorduplication;
 	if(dual_x_carriage_mode == DXC_DUPLICATION_MODE_R || dual_x_carriage_mode == DXC_MIRROR_MODE_R) active_extruder_parked = true;
 	SERIAL_PROTOCOLPAIR("Go unpark -> DXC: ", dual_x_carriage_mode);
+	pause_flag = false;
 }
 
 static DualXMode dual_x_carriage_mode_resume = DEFAULT_DUAL_X_CARRIAGE_MODE;
 static uint8_t active_extruder_resume = 0;
 static motordriver_mode motorModeResume = motordriver_mode::motordefault;
-static bool pause_flag = false;
 static int16_t flow_percentage_save[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(100);
 static int16_t fanSpeedsClassic_resume = 0;
 
@@ -7366,7 +7421,7 @@ inline void gcode_G73(){ //Save State and get back to DefaultMode
 	if(current_position[X_AXIS] != x_home_pos(active_extruder)){
 		SERIAL_PROTOCOLLNPGM("Axes are not at home, pause save failed");
 		return;
-	}	
+	}
 	pause_flag = true;
 	//Save Values	
 	dual_x_carriage_mode_resume = dual_x_carriage_mode;
@@ -7383,16 +7438,17 @@ inline void gcode_G73(){ //Save State and get back to DefaultMode
 	SERIAL_PROTOCOLLNPGM("Paused");
 }
 inline void gcode_G74(){ //Recover State
-	if(pause_flag){
-		fanSpeedsClassic = fanSpeedsClassic_resume;
-		tool_change(active_extruder_resume);	//Just in case there is another tool active
-		active_extruder_parked = false;
-		dual_x_carriage_mode = dual_x_carriage_mode_resume;
-		motorMode = motorModeResume;		
-		COPY(planner.flow_percentage, flow_percentage_save); 
-	}else{
-		SERIAL_PROTOCOLLNPGM("Not paused");
-	}	
+  if (pause_flag){
+    fanSpeedsClassic = fanSpeedsClassic_resume;
+    tool_change(active_extruder_resume);	//Just in case there is another tool active
+    active_extruder_parked = false;
+    dual_x_carriage_mode = dual_x_carriage_mode_resume;
+    motorMode = motorModeResume;		
+    COPY(planner.flow_percentage, flow_percentage_save);
+  } else if (!pause_started) {
+    SERIAL_PROTOCOLLNPGM("Not paused");
+  }
+  pause_started = false;
 }
 // Calib
 float extrusion_multiplier(float distance, float layerh, float hSize=0.4/*default value*/)
@@ -8158,9 +8214,9 @@ inline void gcode_M536(){ // report FRS state and Door Monitoring
 }
 
 inline void gcode_M537(){ // Set Max Led level
-	if(parser.seen('S')){
+	if (parser.seen('S')) {
 		leds_handler.setMaxLevel(parser.value_byte());
-		}else{
+	} else {
 		SERIAL_ECHO_START();
 		SERIAL_ECHOLNPGM("No imput light level");
 	}
@@ -8176,6 +8232,33 @@ inline void gcode_M539() { // Printer stats reset
 
 inline void gcode_M543() { // Printer trigger
 	if (parser.seen('V')) digitalWrite(SDA_PIN,parser.value_byte()); 
+}
+
+inline void gcode_M544() { // Begin print
+  // Reset the feedrate
+  feedrate_percentage = 100;
+  report_feedrate();
+  // Reset the flow percentage of all the extruders
+  for (uint8_t i = 0; i < EXTRUDERS; i++) {
+    planner.flow_percentage[i] = 100;
+    report_flow_percentage(i);
+  }
+  // Expect the first Gcode line to be 0 (Most of the times will be an M101)
+  gcode_LastN = -1;
+  // Reset the print flags
+  pause_started = false;
+  pause_flag = false;
+  is_ending_print = false;
+  // Report the current printer positions
+  planner.synchronize();
+  report_current_position();
+  
+  SERIAL_PROTOCOLLN("Begin print");
+}
+
+inline void gcode_M545() { // End print
+  // Reset the gcode line counter
+  gcode_LastN = 0;
 }
 #endif  //BCN3D Mod
 
@@ -9836,20 +9919,20 @@ inline void gcode_M105() {
         }
       #endif // EXTRA_FAN_SPEED
       const uint16_t s = parser.ushortval('S', 255);      
-	  #if ENABLED(FANSPEED_CLASSIC)
-		if(!parser.byteval('P')) { 
-			fanSpeedsClassic = MIN(s, 255U);
-		}
-		else {
-			fanSpeeds[p] = MIN(s, 255U);
-		}
-	  #else
-	    fanSpeeds[p] = MIN(s, 255U);
-	  #endif
+      #if ENABLED(FANSPEED_CLASSIC)
+      if(!parser.byteval('P')) { 
+        fanSpeedsClassic = MIN(s, 255U);
+      }
+      else {
+        fanSpeeds[p] = MIN(s, 255U);
+      }
+      #else
+      fanSpeeds[p] = MIN(s, 255U);
+      #endif
     }
-	#ifdef BCN3D_MOD
-	fanStastusReport();
-	#endif
+    #ifdef BCN3D_MOD
+    fanStastusReport();
+    #endif
   }
 
   /**
@@ -10228,6 +10311,38 @@ inline void gcode_M109() {
   }
 
 #endif // HAS_HEATED_BED
+
+#ifdef BCN3D_MOD
+inline void gcode_M156() {
+  if (DEBUGGING(DRYRUN)) return;
+  if (get_target_extruder_from_command(156)) return;
+
+  #if ENABLED(SINGLENOZZLE)
+    if (target_extruder != active_extruder) return;
+  #endif
+
+  if (parser.seenval('S')) {
+    const int16_t temp = parser.value_celsius();
+    thermalManager.setTargetHotend(temp, target_extruder);
+  }
+
+  #if HAS_TEMP_SENSOR
+    thermalManager.print_heaterstates();
+    SERIAL_EOL();
+  #endif
+}
+
+#if HAS_HEATED_BED
+inline void gcode_M157() {
+  if (DEBUGGING(DRYRUN)) return;
+  if (parser.seenval('S')) thermalManager.setTargetBed(parser.value_celsius());
+  #if HAS_TEMP_SENSOR
+    thermalManager.print_heaterstates();
+    SERIAL_EOL();
+  #endif
+}
+#endif // HAS_HEATED_BED
+#endif // BCN3D_MOD
 
 /**
  * M110: Set Current Line Number
@@ -11410,11 +11525,28 @@ inline void gcode_M211() {
 
 #endif // HOTENDS > 1
 
+void report_feedrate() {
+  SERIAL_ECHO_START();
+  SERIAL_ECHOPAIR("Feedrate: ", feedrate_percentage);
+  SERIAL_CHAR('%');
+  SERIAL_EOL();
+}
+
 /**
  * M220: Set speed percentage factor, aka "Feed Rate" (M220 S95)
  */
 inline void gcode_M220() {
   if (parser.seenval('S')) feedrate_percentage = parser.value_int();
+  report_feedrate();
+}
+
+void report_flow_percentage(const int target_extruder) {
+  SERIAL_ECHO_START();
+  SERIAL_CHAR('E');
+  SERIAL_CHAR('0' + target_extruder);
+  SERIAL_ECHOPAIR(" Flow: ", planner.flow_percentage[target_extruder]);
+  SERIAL_CHAR('%');
+  SERIAL_EOL();
 }
 
 /**
@@ -11426,14 +11558,7 @@ inline void gcode_M221() {
     planner.flow_percentage[target_extruder] = parser.value_int();
     planner.refresh_e_factor(target_extruder);
   }
-  else {
-    SERIAL_ECHO_START();
-    SERIAL_CHAR('E');
-    SERIAL_CHAR('0' + target_extruder);
-    SERIAL_ECHOPAIR(" Flow: ", planner.flow_percentage[target_extruder]);
-    SERIAL_CHAR('%');
-    SERIAL_EOL();
-  }
+  report_flow_percentage(target_extruder);
 }
 
 /**
@@ -12300,9 +12425,9 @@ inline void gcode_M303() {
  * M400: Finish all moves
  */
 inline void gcode_M400() { 
-	planner.synchronize(); 
-	SERIAL_ECHO_START();
-	SERIAL_ECHOLNPGM(" Idle: no moves");
+  planner.synchronize();
+  SERIAL_ECHO_START();
+  SERIAL_ECHOLNPGM(" Idle: no moves");
 }
 #if HAS_BED_PROBE
 
@@ -14773,7 +14898,7 @@ void process_parsed_command() {
 	  #if defined(BCN3D_MOD)
 	  case 71: gcode_G71(); break;                                // G71: BCN3D Go Park
 	  case 72: gcode_G72(); break;                                // G72: BCN3D Go unPark
-	  case 73: gcode_G73(); break;                                // G71: BCN3D Exec Pause
+	  case 73: gcode_G73(); break;                                // G73: BCN3D Exec Pause
 	  case 74: gcode_G74(); break;                                // G72: BCN3D Exec UnPause  
 	  #endif
 	  
@@ -14869,7 +14994,6 @@ void process_parsed_command() {
 
       case 101: break;                                            // M101: Dummy GCODE
 
-      case 104: gcode_M104(); break;                              // M104: Set Hotend Temperature
       case 110: gcode_M110(); break;                              // M110: Set Current Line Number
       case 111: gcode_M111(); break;                              // M111: Set Debug Flags
 
@@ -14891,11 +15015,18 @@ void process_parsed_command() {
         case 155: gcode_M155(); break;                            // M155: Set Temperature Auto-report Interval
       #endif
 
+      case 104: gcode_M104(); break;                              // M104: Set Hotend Temperature
       case 109: gcode_M109(); break;                              // M109: Set Hotend Temperature. Wait for target.
+      #ifdef BCN3D_MOD
+        case 156: gcode_M156(); break;                            // M156: Set Hotend temperature while the printer is busy
+      #endif
 		
       #if HAS_HEATED_BED
         case 140: gcode_M140(); break;                            // M140: Set Bed Temperature
         case 190: gcode_M190(); break;                            // M190: Set Bed Temperature. Wait for target.
+        #ifdef BCN3D_MOD
+          case 157: gcode_M157(); break;                          // M157: Set Bed temperature while the printer is busy
+        #endif
       #endif
 	  
 	  //#if defined(BCN3D_MOD)
@@ -15107,14 +15238,16 @@ void process_parsed_command() {
         case 504: gcode_M504(); break;                            // M504: Validate EEPROM
       #endif
 	  
-	  #ifdef BCN3D_MOD
-		case 535: gcode_M535(); break;							  // M535: Set Led State
-		case 536: gcode_M536(); break;							  // M536: Report FRS and Door State
-		case 537: gcode_M537(); break;							  // M537: Set led level
-		case 538: gcode_M538(); break;							  // M538: Printer Stats report
-		case 539: gcode_M539(); break;							  // M539: Printer Stats reset
-		case 543: gcode_M543(); break;							  // M543: Printer Stats reset
-	  #endif
+      #ifdef BCN3D_MOD
+        case 535: gcode_M535(); break;							  // M535: Set Led State
+        case 536: gcode_M536(); break;							  // M536: Report FRS and Door State
+        case 537: gcode_M537(); break;							  // M537: Set led level
+        case 538: gcode_M538(); break;							  // M538: Printer Stats report
+        case 539: gcode_M539(); break;							  // M539: Printer Stats reset
+        case 543: gcode_M543(); break;							  // M543: Printer trigger
+        case 544: gcode_M544(); break;							  // M544: Begin print
+        case 545: gcode_M545(); break;							  // M545: End print
+      #endif
 		
       #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
         case 540: gcode_M540(); break;                            // M540: Set Abort on Endstop Hit for SD Printing
@@ -15244,6 +15377,25 @@ void process_next_command() {
   #endif
   process_parsed_command();
 }
+
+#ifdef BCN3D_MOD
+void execute_priority_command(char * const cmd) { 
+  // Parse the priority command
+  parser.parse(cmd);
+  // Identify and execute it
+  if (parser.command_letter == 'M') {
+    switch (parser.codenum) {
+      case 106: gcode_M106(); break;
+      case 156: gcode_M156(); break;
+      case 157: gcode_M157(); break;
+      case 220: gcode_M220(); break;
+      case 221: gcode_M221(); break;
+      case 537: gcode_M537(); break;
+      default: return;
+    }
+  }
+}
+#endif
 
 /**
  * Send a "Resend: nnn" message to the host to
@@ -17154,7 +17306,7 @@ void disable_all_steppers() {
   disable_e_steppers();
 }
 
-void dropSeriabuffer() {
+void dropSerialbuffer() {
 	
 	thermalManager.disable_all_heaters(); // disable heaters
 	
@@ -17167,12 +17319,9 @@ void dropSeriabuffer() {
 }
 
 void execPauseFromSerial() {
-	
-	//MYSERIAL0.clear_buffer(); // drop serial buffer
-			
 	clear_command_queue(); // clear marlin queue
 	discard_serial = DiscardSerialReason::PAUSE; // Release the flag once Serial buffer is Empty
-
+  pause_started = true;
 }
 
 /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11796,25 +11796,6 @@ inline void gcode_M226() {
 	   }
 	   else{
 		   thermalManager.report_sensors_names();
-		   SERIAL_ECHO_START();
-		#if  THERMISTORHEATER_0
-			SERIAL_ECHOLNPAIR("Heater 0 sensor: ", sensor_name_heater0);
-		#endif
-		#if  THERMISTORHEATER_1
-			SERIAL_ECHOLNPAIR("Heater 1 sensor: ", sensor_name_heater1);
-		#endif
-		#if  THERMISTORHEATER_2
-			SERIAL_ECHOLNPAIR("Heater 2 sensor: ", sensor_name_heater2);
-		#endif
-		#if  THERMISTORHEATER_3
-			SERIAL_ECHOLNPAIR("Heater 3 sensor: ", sensor_name_heater3);
-		#endif
-		#if  THERMISTORHEATER_4
-			SERIAL_ECHOLNPAIR("Heater 4 sensor: ", sensor_name_heater4);
-		#endif
-		#if  THERMISTORBED
-			SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
-		#endif
 	   }
    }
    /*

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7466,7 +7466,7 @@ void z_test_print_code(uint8_t tool, float x_offset, float hSize=0.4/*default va
 	current_position[Z_AXIS] = 2; 
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS],current_position[Z_AXIS],current_position[E_AXIS], MMM_TO_MMS(600),active_extruder); // move Z
 
-	current_position[E_AXIS]-=4;
+	current_position[E_AXIS]-= RETRACT_PRINTER_FACTOR;
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS],current_position[Z_AXIS],current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST),active_extruder); // Retract
 	
 	
@@ -7482,7 +7482,7 @@ void z_test_print_code(uint8_t tool, float x_offset, float hSize=0.4/*default va
 	planner.synchronize();
 	//POS A done
 	
-	current_position[E_AXIS]+=4.1;
+	current_position[E_AXIS]+=(RETRACT_PRINTER_FACTOR+0.1);
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Purge
 	
 	
@@ -7520,7 +7520,7 @@ void z_test_print_code(uint8_t tool, float x_offset, float hSize=0.4/*default va
 	}
 	
 	
-	current_position[E_AXIS]-=4; 
+	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR; 
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS],current_position[Z_AXIS],current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST),active_extruder);// Retract
 	
 	//RETIRE HOTEND

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -602,32 +602,37 @@ bool waiting_resend_confirmation = false;
 #endif
 
 //Bed size
-_UNUSED	static float xBedSize = 420;
-_UNUSED	static float yBedSize = 300;
+static float xBedSize = X_BED_SIZE;
+static float yBedSize = Y_BED_SIZE;
 
-//Know positions
-_UNUSED static float x_screw_bed_calib_1 = (X1_MIN_POS + 262.9);
-_UNUSED static float y_screw_bed_calib_1 = (Y_MAX_POS + 30.3);
-_UNUSED static float x_screw_bed_calib_2 = (X1_MIN_POS + 54.4);
-_UNUSED static float y_screw_bed_calib_2 = (Y_MAX_POS - 297.2);
-_UNUSED static float x_screw_bed_calib_3 = (X1_MIN_POS + 471.4);
-_UNUSED static float y_screw_bed_calib_3 = (Y_MAX_POS - 297.2);
+//Knob positions
+static float x_screw_bed_calib_1 = SCREW_BED_1_X;
+static float y_screw_bed_calib_1 = SCREW_BED_1_Y;
+static float x_screw_bed_calib_2 = SCREW_BED_2_X;
+static float y_screw_bed_calib_2 = SCREW_BED_2_Y;
+static float x_screw_bed_calib_3 = SCREW_BED_3_X;
+static float y_screw_bed_calib_3 = SCREW_BED_3_Y;
 
 //Probe positions
-_UNUSED static float x_probe_left_extr[3] = {X_SIGMA_PROBE_1_LEFT_EXTR, X_SIGMA_PROBE_2_LEFT_EXTR, X_SIGMA_PROBE_3_LEFT_EXTR};
-_UNUSED static float y_probe_left_extr[3] = {Y_SIGMA_PROBE_1_LEFT_EXTR, Y_SIGMA_PROBE_2_LEFT_EXTR, Y_SIGMA_PROBE_3_LEFT_EXTR};
-_UNUSED static float x_probe_right_extr[3] = {X_SIGMA_PROBE_1_RIGHT_EXTR, X_SIGMA_PROBE_2_RIGHT_EXTR, X_SIGMA_PROBE_3_RIGHT_EXTR};
-_UNUSED static float y_probe_right_extr[3] = {Y_SIGMA_PROBE_1_RIGHT_EXTR, Y_SIGMA_PROBE_2_RIGHT_EXTR, Y_SIGMA_PROBE_3_RIGHT_EXTR};
+static float x_probe_left_extr[3] = {X_SIGMA_PROBE_1_LEFT_EXTR, X_SIGMA_PROBE_2_LEFT_EXTR, X_SIGMA_PROBE_3_LEFT_EXTR};
+static float y_probe_left_extr[3] = {Y_SIGMA_PROBE_1_LEFT_EXTR, Y_SIGMA_PROBE_2_LEFT_EXTR, Y_SIGMA_PROBE_3_LEFT_EXTR};
+static float x_probe_right_extr[3] = {X_SIGMA_PROBE_1_RIGHT_EXTR, X_SIGMA_PROBE_2_RIGHT_EXTR, X_SIGMA_PROBE_3_RIGHT_EXTR};
+static float y_probe_right_extr[3] = {Y_SIGMA_PROBE_1_RIGHT_EXTR, Y_SIGMA_PROBE_2_RIGHT_EXTR, Y_SIGMA_PROBE_3_RIGHT_EXTR};
+
+//Z safe homming points
+#if ENABLED(Z_SAFE_HOMING)
+static float z_safe_homing_x_point = Z_SAFE_HOMING_X_POINT;
+static float z_safe_homing_y_point = Z_SAFE_HOMING_Y_POINT;
+#endif
 
 //Gap bed leveling	
-_UNUSED static float x_gap_avoid_collision_l = X_GAP_AVOID_COLLISION_LEFT;
-_UNUSED static float x_gap_avoid_collision_r = X_GAP_AVOID_COLLISION_RIGHT;
+static float x_gap_avoid_collision_l = X_GAP_AVOID_COLLISION_LEFT;
+static float x_gap_avoid_collision_r = X_GAP_AVOID_COLLISION_RIGHT;
 
 //Print settings
-_UNUSED static float retract_printer_factor = 8;
-_UNUSED static float retract_print_test_factor = 8;
-_UNUSED static float purge_printer_factor = 20;
-
+static float retract_printer_factor = RETRACT_PRINTER_FACTOR;
+static float retract_print_test_factor = RETRACT_PRINT_TEST_FACTOR;
+static float purge_printer_factor = PURGE_PRINTER_FACTOR;
 
 #endif
 
@@ -4442,8 +4447,8 @@ inline void gcode_G4() {
     /**
      * Move the Z probe (or just the nozzle) to the safe homing point
      */
-    destination[X_AXIS] = Z_SAFE_HOMING_X_POINT;
-    destination[Y_AXIS] = Z_SAFE_HOMING_Y_POINT;
+    destination[X_AXIS] = z_safe_homing_x_point;
+    destination[Y_AXIS] = z_safe_homing_y_point;
     destination[Z_AXIS] = current_position[Z_AXIS]; // Z is already at the right height
 
     #if HOMING_Z_WITH_PROBE
@@ -7466,7 +7471,7 @@ void z_test_print_code(uint8_t tool, float x_offset, float hSize=0.4/*default va
 	current_position[Z_AXIS] = 2; 
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS],current_position[Z_AXIS],current_position[E_AXIS], MMM_TO_MMS(600),active_extruder); // move Z
 
-	current_position[E_AXIS]-= RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-= retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS],current_position[Z_AXIS],current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST),active_extruder); // Retract
 	
 	
@@ -7482,7 +7487,7 @@ void z_test_print_code(uint8_t tool, float x_offset, float hSize=0.4/*default va
 	planner.synchronize();
 	//POS A done
 	
-	current_position[E_AXIS]+=(RETRACT_PRINTER_FACTOR+0.1);
+	current_position[E_AXIS]+=(retract_printer_factor+0.1);
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Purge
 	
 	
@@ -7520,7 +7525,7 @@ void z_test_print_code(uint8_t tool, float x_offset, float hSize=0.4/*default va
 	}
 	
 	
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR; 
+	current_position[E_AXIS]-=retract_printer_factor; 
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS],current_position[Z_AXIS],current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST),active_extruder);// Retract
 	
 	//RETIRE HOTEND
@@ -7608,11 +7613,11 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 	planner.synchronize();
 
 	
-	current_position[E_AXIS]+=PURGE_PRINTER_FACTOR;
+	current_position[E_AXIS]+=purge_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(50) , active_extruder);
 	planner.synchronize();
 
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-=retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 	planner.synchronize();
 	
@@ -7628,7 +7633,7 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 			current_position[Z_AXIS] = LINES_LAYER_HEIGHT_XY;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 8, active_extruder);
 			
-			current_position[E_AXIS]+=(RETRACT_PRINTER_FACTOR+0.1);
+			current_position[E_AXIS]+=(retract_printer_factor+0.1);
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(1200), active_extruder);//Retract
 			planner.synchronize();
 
@@ -7658,7 +7663,7 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 
 		
 	}
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-=retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST) , active_extruder);
 	planner.synchronize();
 
@@ -7670,11 +7675,11 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 	planner.synchronize();
 
 	//Purge & up
-	current_position[E_AXIS]+=PURGE_PRINTER_FACTOR;
+	current_position[E_AXIS]+=purge_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(50) , active_extruder);
 	planner.synchronize();
 
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-=retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 	planner.synchronize();
 
@@ -7692,7 +7697,7 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 100 , active_extruder);
 	planner.synchronize();
 	
-	current_position[E_AXIS]+=(RETRACT_PRINTER_FACTOR+0.1);
+	current_position[E_AXIS]+=(retract_printer_factor+0.1);
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST) , active_extruder);
 	planner.synchronize();
 	
@@ -7719,7 +7724,7 @@ inline void gcode_G241() {//BCN3D Calib pattern for X axis
 		draw_print_line(X_AXIS, 37.5,LINES_LAYER_HEIGHT_XY, hotend_size_setup[1]);
 		
 	}
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-=retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST) , active_extruder);
 	planner.synchronize();
 	current_position[Z_AXIS]+=Z_HOMING_HEIGHT;
@@ -7772,11 +7777,11 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 
 	//2)Extruder one prints
 	//Purge & up
-	current_position[E_AXIS]+=PURGE_PRINTER_FACTOR;
+	current_position[E_AXIS]+=purge_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(50), active_extruder);
 	planner.synchronize();
 	
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-=retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 	planner.synchronize();
 
@@ -7791,7 +7796,7 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 			current_position[Z_AXIS] = LINES_LAYER_HEIGHT_XY;
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 8, active_extruder);
 			planner.synchronize();
-			current_position[E_AXIS]+=(RETRACT_PRINTER_FACTOR+0.1);
+			current_position[E_AXIS]+=(retract_printer_factor+0.1);
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST) , active_extruder);
 			planner.synchronize();
 
@@ -7820,7 +7825,7 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 		}
 	}
 	
-	current_position[E_AXIS]-=RETRACT_PRINT_TEST_FACTOR;
+	current_position[E_AXIS]-=retract_print_test_factor;
 	planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);
 	planner.synchronize();
 	
@@ -7830,10 +7835,10 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 	tool_change(1);	
 
 	//Purge & up
-	current_position[E_AXIS]+=PURGE_PRINTER_FACTOR;
+	current_position[E_AXIS]+=purge_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(50) , active_extruder);
 	
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-=retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 	planner.synchronize();
 
@@ -7850,7 +7855,7 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 8, active_extruder);
 			planner.synchronize();
 			
-			current_position[E_AXIS]+=(RETRACT_PRINTER_FACTOR+0.1);
+			current_position[E_AXIS]+=(retract_printer_factor+0.1);
 			planner.buffer_line(current_position[X_AXIS],current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST) , active_extruder);
 			planner.synchronize();			
 			
@@ -7878,7 +7883,7 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 		}
 		
 	}
-	current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+	current_position[E_AXIS]-=retract_printer_factor;
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 	planner.synchronize();
 	current_position[Z_AXIS]+=Z_HOMING_HEIGHT;
@@ -8020,16 +8025,16 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	vector_3 planeNormal_1 = vector_3::cross(from_3_to_1_1, from_3_to_2_1); // Point 3 is 2 on the left
 	planeNormal_1 = vector_3(planeNormal_1.x, planeNormal_1.y, planeNormal_1.z);
 	
-	float Zscroll_0=(-planeNormal_0.x*(CARGOL_1_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_0.y*(CARGOL_1_Y-y_probe_left_extr[2]-CARGOL_1_Y/2.0))/planeNormal_0.z;
-	float Zscroll_1=(-planeNormal_1.x*(CARGOL_1_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_1_Y-y_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
+	float Zscroll_0=(-planeNormal_0.x*(x_screw_bed_calib_1-x_probe_left_extr[0]-x_screw_bed_calib_1)-planeNormal_0.y*(y_screw_bed_calib_1-y_probe_left_extr[2]-y_screw_bed_calib_1/2.0))/planeNormal_0.z;
+	float Zscroll_1=(-planeNormal_1.x*(x_screw_bed_calib_1-x_probe_left_extr[0]-x_screw_bed_calib_1)-planeNormal_1.y*(y_screw_bed_calib_1-y_probe_left_extr[2]-y_screw_bed_calib_1/2.0))/planeNormal_1.z;
 	
 	//float z1_0=(-planeNormal_0.x*0.0-planeNormal_0.y*(Y_SIGMA_PROBE_1_LEFT_EXTR-Y_SIGMA_PROBE_3_LEFT_EXTR))/planeNormal_0.z;
-	float z2_0=(-planeNormal_0.x*(CARGOL_2_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_0.y*(CARGOL_2_Y-y_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_0.z;
-	float z3_0=(-planeNormal_0.x*(CARGOL_3_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_0.y*(CARGOL_3_Y-y_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_0.z;
+	float z2_0=(-planeNormal_0.x*(x_screw_bed_calib_2-x_probe_left_extr[0]-x_screw_bed_calib_1)-planeNormal_0.y*(y_screw_bed_calib_2-y_probe_left_extr[2]-y_screw_bed_calib_1/2.0))/planeNormal_0.z;
+	float z3_0=(-planeNormal_0.x*(x_screw_bed_calib_3-x_probe_left_extr[0]-x_screw_bed_calib_1)-planeNormal_0.y*(y_screw_bed_calib_3-y_probe_left_extr[2]-y_screw_bed_calib_1/2.0))/planeNormal_0.z;
 	
 	//float z1_1=(-planeNormal_1.x*(X_SIGMA_PROBE_1_RIGHT_EXTR-X_SIGMA_PROBE_1_LEFT_EXTR)-planeNormal_1.y*(Y_SIGMA_PROBE_1_RIGHT_EXTR-Y_SIGMA_PROBE_3_RIGHT_EXTR))/planeNormal_1.z;
-	float z2_1=(-planeNormal_1.x*(CARGOL_2_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_2_Y-x_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
-	float z3_1=(-planeNormal_1.x*(CARGOL_3_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_3_Y-x_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
+	float z2_1=(-planeNormal_1.x*(x_screw_bed_calib_2-x_probe_left_extr[0]-x_screw_bed_calib_1)-planeNormal_1.y*(y_screw_bed_calib_2-y_probe_left_extr[2]-y_screw_bed_calib_1/2.0))/planeNormal_1.z;
+	float z3_1=(-planeNormal_1.x*(x_screw_bed_calib_3-x_probe_left_extr[0]-x_screw_bed_calib_1)-planeNormal_1.y*(y_screw_bed_calib_3-y_probe_left_extr[2]-y_screw_bed_calib_1/2.0))/planeNormal_1.z;
 	
 	
 	SERIAL_PROTOCOLPGM("planeNormal_0.x: ");
@@ -11555,7 +11560,8 @@ inline void gcode_M226() {
 
 #endif // BABYSTEPPING
 
-   /*
+#ifdef BCN3D_MOD
+  /*
 	* M281: Set axis max travel. (X/Y/Z) S<0 maximum (default) or 1 maximum>                                                                    
 	*/
    inline void gcode_M281() {
@@ -11602,7 +11608,6 @@ inline void gcode_M226() {
 		   }			   
 		}
 		else{
-			SERIAL_ECHO_START();
 			SERIAL_ECHOLNPAIR("Min Axis Travel X: ", base_min_pos(X_AXIS));
 			SERIAL_ECHOLNPAIR("Max Axis Travel X: ", base_max_pos(X_AXIS));
 			SERIAL_ECHOLNPAIR("Min Axis Travel Y: ", base_min_pos(Y_AXIS));
@@ -11624,7 +11629,6 @@ inline void gcode_M226() {
 			duplicate_extruder_x_offset = xBedSize/2.0;
 	   }
 	   else{
-		   SERIAL_ECHO_START();
 		   SERIAL_ECHOLNPAIR("Bed Size X: ", xBedSize);
 		   SERIAL_ECHOLNPAIR("Bed Size Y: ", yBedSize);
 		   SERIAL_ECHOLNPAIR("Duplication Offset: ", duplicate_extruder_x_offset);
@@ -11644,9 +11648,8 @@ inline void gcode_M226() {
 		   }
 	   }
 	   else{
-		   SERIAL_ECHO_START();
-		   SERIAL_ECHOLNPAIR("Home safe point X: ", Z_SAFE_HOMING_X_POINT);
-		   SERIAL_ECHOLNPAIR("Home safe point Y: ", Z_SAFE_HOMING_Y_POINT);
+		   SERIAL_ECHOLNPAIR("Home safe point X: ", z_safe_homing_x_point);
+		   SERIAL_ECHOLNPAIR("Home safe point Y: ", z_safe_homing_y_point);
 	   }	   
    }
    /*
@@ -11676,13 +11679,12 @@ inline void gcode_M226() {
 		   }
 	   }
 	   else{
-		   SERIAL_ECHO_START();
-		   SERIAL_ECHOLNPAIR("Knob 1 x position: ", CARGOL_1_X);
-		   SERIAL_ECHOLNPAIR("Knob 1 y position: ", CARGOL_1_Y);
-		   SERIAL_ECHOLNPAIR("Knob 2 x position: ", CARGOL_2_X);
-		   SERIAL_ECHOLNPAIR("Knob 2 y position: ", CARGOL_2_Y);
-		   SERIAL_ECHOLNPAIR("Knob 3 x position: ", CARGOL_3_X);
-		   SERIAL_ECHOLNPAIR("Knob 3 y position: ", CARGOL_3_Y);
+		   SERIAL_ECHOLNPAIR("Knob 1 x position: ", x_screw_bed_calib_1);
+		   SERIAL_ECHOLNPAIR("Knob 1 y position: ", y_screw_bed_calib_1);
+		   SERIAL_ECHOLNPAIR("Knob 2 x position: ", x_screw_bed_calib_2);
+		   SERIAL_ECHOLNPAIR("Knob 2 y position: ", y_screw_bed_calib_2);
+		   SERIAL_ECHOLNPAIR("Knob 3 x position: ", x_screw_bed_calib_3);
+		   SERIAL_ECHOLNPAIR("Knob 3 y position: ", y_screw_bed_calib_3);
 	   }	   
    }
    /*
@@ -11734,16 +11736,17 @@ inline void gcode_M226() {
 		   }		  
 	   }
 	   else{
-		   SERIAL_ECHO_START();
-		   SERIAL_ECHOLNPGM("Left Probe:");
-		   SERIAL_ECHOPAIR("Probe 1 x: ", x_probe_left_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[0]);
-		   SERIAL_ECHOPAIR("Probe 2 x: ", x_probe_left_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[1]);
-		   SERIAL_ECHOPAIR("Probe 3 x: ", x_probe_left_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[2]);
-		   SERIAL_ECHOLNPGM("Right Probe:");
-		   SERIAL_ECHOPAIR("Probe 1 x: ", x_probe_right_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[0]);
-		   SERIAL_ECHOPAIR("Probe 2 x: ", x_probe_right_extr[1]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[1]);
-		   SERIAL_ECHOPAIR("Probe 3 x: ", x_probe_right_extr[2]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[2]);
-	   }	   
+		   SERIAL_ECHOPGM("Left Probe:");
+		   SERIAL_ECHOPAIR("  Probe 1 x: ", x_probe_left_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[0]);
+		   SERIAL_ECHOPAIR("  Probe 2 x: ", x_probe_left_extr[1]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[1]);
+		   SERIAL_ECHOPAIR("  Probe 3 x: ", x_probe_left_extr[2]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[2]);
+		   SERIAL_EOL();
+		   SERIAL_ECHOPGM("Right Probe:");
+		   SERIAL_ECHOPAIR("  Probe 1 x: ", x_probe_right_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[0]);
+		   SERIAL_ECHOPAIR("  Probe 2 x: ", x_probe_right_extr[1]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[1]);
+		   SERIAL_ECHOPAIR("  Probe 3 x: ", x_probe_right_extr[2]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[2]);
+		   SERIAL_EOL();
+     }	   
    }
    /*
 	* M286: Set collision avoidance Machine on bed leveling                                                             
@@ -11758,7 +11761,6 @@ inline void gcode_M226() {
 			x_gap_avoid_collision_r = xr_coords;
 	   }
 	   else{
-		   SERIAL_ECHO_START();
 		   SERIAL_ECHOLNPAIR("Collision Avoidance L: ", x_gap_avoid_collision_l);
 		   SERIAL_ECHOLNPAIR("Collision Avoidance R: ", x_gap_avoid_collision_r);
 	   }
@@ -11773,10 +11775,9 @@ inline void gcode_M226() {
 			purge_printer_factor = parser.floatval('P');	
 	   }
 	   else{
-		   SERIAL_ECHO_START();
-		   SERIAL_ECHOLNPAIR("RETRACT_PRINTER_FACTOR: ", retract_printer_factor);
-		   SERIAL_ECHOLNPAIR("RETRACT_PRINT_TEST_FACTOR: ", retract_print_test_factor);
-		   SERIAL_ECHOLNPAIR("PURGE_PRINTER_FACTOR: ", purge_printer_factor);
+		   SERIAL_ECHOLNPAIR("retract_printer_factor: ", retract_printer_factor);
+		   SERIAL_ECHOLNPAIR("retract_print_test_factor: ", retract_print_test_factor);
+		   SERIAL_ECHOLNPAIR("purge_printer_factor: ", purge_printer_factor);
 	   }
    }
    /*
@@ -11807,53 +11808,140 @@ inline void gcode_M226() {
     */
    
    inline void gcode_M306() {
-	   if (parser.seen('P') && parser.seen('X') && parser.seen('S')){
-			if (parser.intval('P')<HOTENDS){
-				if (!parser.boolval('S')){
-					min_temp_array[parser.intval('P')]=parser.floatval('X');
+	   if (parser.seen('P') && parser.seen('X') && parser.seen('S')) {
+			if (parser.intval('P')<HOTENDS) {
+				if (parser.boolval('S')) {
+					thermalManager.set_heater_max_temp(parser.intval('P'), parser.floatval('X'));
+				} else {
+					thermalManager.set_heater_min_temp(parser.intval('P'), parser.floatval('X'));
 				}
-				else {
-					max_temp_array[parser.intval('P')]=parser.floatval('X');
-				}
 			}
-	   }
-	   else if (parser.seen('B') && parser.seen('X') && parser.seen('S')){
-			if (!parser.boolval('S')){
-				min_temp_array[5]=parser.floatval('X');
+	   } else if (parser.seen('B') && parser.seen('X') && parser.seen('S')) {
+			if (parser.boolval('S')) {
+				thermalManager.set_bed_max_temp(parser.floatval('X'));
+			} else {
+				thermalManager.set_bed_min_temp(parser.floatval('X'));
 			}
-			else {
-				max_temp_array[5]=parser.floatval('X');
-			}
-	   }
-	   else {
-		   SERIAL_ECHO_START();
+	   } else {
 		   #if THERMISTORHEATER_0
-		   SERIAL_ECHOLNPAIR("Min temp heater 0: ", min_temp_array[0]);
-		   SERIAL_ECHOLNPAIR("Max temp heater 0: ", max_temp_array[0]);
+		   SERIAL_ECHOLNPAIR("Min temp heater 0: ", thermalManager.get_heater_min_temp(0));
+		   SERIAL_ECHOLNPAIR("Max temp heater 0: ", thermalManager.get_heater_max_temp(0));
 		   #endif
 		   #if THERMISTORHEATER_1
-		   SERIAL_ECHOLNPAIR("Min temp heater 1: ", min_temp_array[1]);
-		   SERIAL_ECHOLNPAIR("Max temp heater 1: ", max_temp_array[1]);
+		   SERIAL_ECHOLNPAIR("Min temp heater 1: ", thermalManager.get_heater_min_temp(1));
+		   SERIAL_ECHOLNPAIR("Max temp heater 1: ", thermalManager.get_heater_max_temp(1));
 		   #endif
 		   #if THERMISTORHEATER_2
-		   SERIAL_ECHOLNPAIR("Min temp heater 2: ", min_temp_array[2]);
-		   SERIAL_ECHOLNPAIR("Max temp heater 2: ", max_temp_array[2]);
+		   SERIAL_ECHOLNPAIR("Min temp heater 2: ", thermalManager.get_heater_min_temp(2));
+		   SERIAL_ECHOLNPAIR("Max temp heater 2: ", thermalManager.get_heater_max_temp(2));
 		   #endif
 		   #if THERMISTORHEATER_3
-		   SERIAL_ECHOLNPAIR("Min temp heater 3: ", min_temp_array[3]);
-		   SERIAL_ECHOLNPAIR("Max temp heater 3: ", max_temp_array[3]);
+		   SERIAL_ECHOLNPAIR("Min temp heater 3: ", thermalManager.get_heater_min_temp(3));
+		   SERIAL_ECHOLNPAIR("Max temp heater 3: ", thermalManager.get_heater_max_temp(3));
 		   #endif
 		   #if THERMISTORHEATER_4
-		   SERIAL_ECHOLNPAIR("Min temp heater 4: ", min_temp_array[4]);
-		   SERIAL_ECHOLNPAIR("Max temp heater 4: ", max_temp_array[4]);
+		   SERIAL_ECHOLNPAIR("Min temp heater 4: ", thermalManager.get_heater_min_temp(4));
+		   SERIAL_ECHOLNPAIR("Max temp heater 4: ", thermalManager.get_heater_max_temp(4));
 		   #endif
 		   #ifdef THERMISTORBED 
-		   SERIAL_ECHOLNPAIR("Min temp bed: ", min_temp_array[5]);
-		   SERIAL_ECHOLNPAIR("Max temp bed: ", max_temp_array[5]);
+		   SERIAL_ECHOLNPAIR("Min temp bed: ", thermalManager.get_bed_min_temp());
+		   SERIAL_ECHOLNPAIR("Max temp bed: ", thermalManager.get_bed_max_temp());
 		   #endif
 	   }
    }
-   
+  
+  inline void gcode_M310() {
+    /* Thermal settings */
+    // Heaters
+    #if THERMISTORHEATER_0
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=0]:tempSensorID=>", thermalManager.get_heater_sensor_id(0));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=0]:minTemp=>", thermalManager.get_heater_min_temp(0));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=0]:maxTemp=>", thermalManager.get_heater_max_temp(0));
+    #endif
+    #if THERMISTORHEATER_1
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=1]:tempSensorID=>", thermalManager.get_heater_sensor_id(1));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=1]:minTemp=>", thermalManager.get_heater_min_temp(1));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=1]:maxTemp=>", thermalManager.get_heater_max_temp(1));
+    #endif
+    #if THERMISTORHEATER_2
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=2]:tempSensorID=>", thermalManager.get_heater_sensor_id(2));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=2]:minTemp=>", thermalManager.get_heater_min_temp(2));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=2]:maxTemp=>", thermalManager.get_heater_max_temp(2));
+    #endif
+    #if THERMISTORHEATER_3
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=3]:tempSensorID=>", thermalManager.get_heater_sensor_id(3));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=3]:minTemp=>", thermalManager.get_heater_min_temp(3));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=3]:maxTemp=>", thermalManager.get_heater_max_temp(3));
+    #endif
+    #if THERMISTORHEATER_4
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=4]:tempSensorID=>", thermalManager.get_heater_sensor_id(4));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=4]:minTemp=>", thermalManager.get_heater_min_temp(4));
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:heaters[index=4]:maxTemp=>", thermalManager.get_heater_max_temp(4));
+    #endif
+    // Bed
+    #ifdef THERMISTORBED
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:bed:tempSensorID=>", thermalManager.get_bed_sensor_id());
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:bed:minTemp=>", thermalManager.get_bed_min_temp());
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:bed:maxTemp=>", thermalManager.get_bed_max_temp());
+    #endif
+    // Chamber
+    #ifdef THERMISTORCHAMBER
+    SERIAL_ECHOLNPAIR("conf:thermalSettings:chamber:tempSensorID=>", thermalManager.get_chamber_sensor_id());
+    #endif
+
+    /* Bed parameters */
+    // Dimensions
+    SERIAL_ECHOLNPAIR("conf:bed:dimensions:X=>", xBedSize);
+    SERIAL_ECHOLNPAIR("conf:bed:dimensions:Y=>", yBedSize);
+    // Z safe homing points
+    SERIAL_ECHOLNPAIR("conf:bed:ZSafeHomingPoints:X=>", z_safe_homing_x_point);
+    SERIAL_ECHOLNPAIR("conf:bed:ZSafeHomingPoints:Y=>", z_safe_homing_y_point);
+    // Leveling colision avoidance
+    SERIAL_ECHOLNPAIR("conf:bed:levelingColisionAvoidance:left=>", x_gap_avoid_collision_l);
+    SERIAL_ECHOLNPAIR("conf:bed:levelingColisionAvoidance:right=>", x_gap_avoid_collision_r);
+
+    /* Positions */
+    // Axes limits
+    SERIAL_ECHOLNPAIR("conf:positions:axesLimits:min:X=>", base_min_pos(X_AXIS));
+    SERIAL_ECHOLNPAIR("conf:positions:axesLimits:max:X=>", base_max_pos(X_AXIS));
+    SERIAL_ECHOLNPAIR("conf:positions:axesLimits:min:Y=>", base_min_pos(Y_AXIS));
+    SERIAL_ECHOLNPAIR("conf:positions:axesLimits:max:Y=>", base_max_pos(Y_AXIS));
+    SERIAL_ECHOLNPAIR("conf:positions:axesLimits:min:Z=>", base_min_pos(Z_AXIS));
+    SERIAL_ECHOLNPAIR("conf:positions:axesLimits:max:Z=>", base_max_pos(Z_AXIS));
+    // Bed leveling knobs
+    SERIAL_ECHOLNPAIR("conf:positions:bedLevelingKnobs[knobIndex=1]:X=>", x_screw_bed_calib_1);
+    SERIAL_ECHOLNPAIR("conf:positions:bedLevelingKnobs[knobIndex=1]:Y=>", y_screw_bed_calib_1);
+    SERIAL_ECHOLNPAIR("conf:positions:bedLevelingKnobs[knobIndex=2]:X=>", x_screw_bed_calib_2);
+    SERIAL_ECHOLNPAIR("conf:positions:bedLevelingKnobs[knobIndex=2]:Y=>", y_screw_bed_calib_2);
+    SERIAL_ECHOLNPAIR("conf:positions:bedLevelingKnobs[knobIndex=3]:X=>", x_screw_bed_calib_3);
+    SERIAL_ECHOLNPAIR("conf:positions:bedLevelingKnobs[knobIndex=3]:Y=>", y_screw_bed_calib_3);
+    // Probes
+    for (int i = 0; i < 3; i++) {
+      SERIAL_ECHOPGM("conf:positions:probes[extruderIndex=0,probeIndex=");
+      SERIAL_ECHO(i+1);
+      SERIAL_ECHOLNPAIR("]:X=>", x_probe_left_extr[i]);
+      SERIAL_ECHOPGM("conf:positions:probes[extruderIndex=0,probeIndex=");
+      SERIAL_ECHO(i+1);
+      SERIAL_ECHOLNPAIR("]:Y=>", y_probe_left_extr[i]);
+    }
+    for (int i = 0; i < 3; i++) {
+      SERIAL_ECHOPGM("conf:positions:probes[extruderIndex=1,probeIndex=");
+      SERIAL_ECHO(i+1);
+      SERIAL_ECHOLNPAIR("]:X=>", x_probe_right_extr[i]);
+      SERIAL_ECHOPGM("conf:positions:probes[extruderIndex=1,probeIndex=");
+      SERIAL_ECHO(i+1);
+      SERIAL_ECHOLNPAIR("]:Y=>", y_probe_right_extr[i]);
+    }
+
+    /* Print parameters */
+    SERIAL_ECHOLNPAIR("conf:printParameters:retractPrinterFactor=>", retract_printer_factor);
+    SERIAL_ECHOLNPAIR("conf:printParameters:retractPrintTestFactor=>", retract_print_test_factor);
+    SERIAL_ECHOLNPAIR("conf:printParameters:purgePrinterFactor=>", purge_printer_factor);
+
+    /* End of config */
+    SERIAL_ECHOLNPGM("Config end");
+  }
+#endif
    
 #if HAS_BUZZER
 
@@ -14898,14 +14986,16 @@ void process_parsed_command() {
         case 280: gcode_M280(); break;                            // M280: Set Servo Position
       #endif
 	  
-		case 281: gcode_M281(); break;							  // M281: Set Axis Maximum Travel
-		case 282: gcode_M282(); break;							  // M282: Set bed size
-		case 283: gcode_M283(); break;							  // M283: Set home safe point
-		case 284: gcode_M284(); break;							  // M284: Set knob position
-		case 285: gcode_M285(); break;							  // M285: Set probe position
-		case 286: gcode_M286(); break;							  // M286: Collision avoidance bed leveling
-		case 287: gcode_M287(); break;							  // M287: Set printing settings
-		
+      #ifdef BCN3D_MOD
+        case 281: gcode_M281(); break;                            // M281: Set Axis Maximum Travel
+        case 282: gcode_M282(); break;                            // M282: Set bed size
+        case 283: gcode_M283(); break;                            // M283: Set home safe point
+        case 284: gcode_M284(); break;                            // M284: Set knob position
+        case 285: gcode_M285(); break;                            // M285: Set probe position
+        case 286: gcode_M286(); break;                            // M286: Collision avoidance bed leveling
+        case 287: gcode_M287(); break;                            // M287: Set printing settings
+      #endif
+
       #if ENABLED(BABYSTEPPING)
         case 290: gcode_M290(); break;                            // M290: Babystepping
       #endif
@@ -14927,8 +15017,16 @@ void process_parsed_command() {
       #if ENABLED(PIDTEMPBED)
         case 304: gcode_M304(); break;                            // M304: Set Bed PID parameters
       #endif
-		case 305: gcode_M305(); break;							  // M305: BCN3D_MOD to override temp sensor
-		case 306: gcode_M306(); break;
+
+      #ifdef BCN3D_MOD
+        case 305: gcode_M305(); break;                            // M305: Overrides the temperature sensor ID
+        case 306: gcode_M306(); break;                            // M306: Sets the temperature max and min
+      #endif
+      
+      #ifdef BCN3D_MOD
+        case 310: gcode_M310(); break;                            // M310: Prints the loaded configuration
+      #endif
+
       #if HAS_MICROSTEPS
         case 350: gcode_M350(); break;                            // M350: Set microstepping mode. Warning: Steps per unit remains unchanged. S code sets stepping mode for all drivers.
         case 351: gcode_M351(); break;                            // M351: Toggle MS1 MS2 pins directly, S# determines MS1 or MS2, X# sets the pin high/low.
@@ -16240,7 +16338,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							planner.flow_percentage[active_extruder] = 100;
 							planner.refresh_e_factor(active_extruder);
 							COPY(fanSpeeds,fanSpeeds_raft);
-							current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+							current_position[E_AXIS]-=retract_printer_factor;
 							planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 							planner.synchronize();
 							current_position[Z_AXIS] = 5;
@@ -16254,7 +16352,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							dual_mode_duplication_extruder_parked(true);/*true*/
 							Flag_Raft_Dual_Mode_On = true;
 							
-							current_position[E_AXIS] = -(RETRACT_PRINTER_FACTOR);
+							current_position[E_AXIS] = -(retract_printer_factor);
 							planner.set_e_position_mm(current_position[E_AXIS]);
 						}
 					}else{
@@ -16273,7 +16371,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							planner.flow_percentage[active_extruder] = 100;
 							planner.refresh_e_factor(active_extruder);
 							COPY(fanSpeeds,fanSpeeds_raft);
-							current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+							current_position[E_AXIS]-=retract_printer_factor;
 							planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 							planner.synchronize();
 							current_position[Z_AXIS] = 5;
@@ -16287,7 +16385,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							current_position[X_AXIS] = x_home_pos(0);
 							dual_mode_duplication_extruder_parked(true);/*true*/
 							Flag_Raft_Dual_Mode_On = true;
-							current_position[E_AXIS] = -(RETRACT_PRINTER_FACTOR);
+							current_position[E_AXIS] = -(retract_printer_factor);
 							planner.set_e_position_mm(current_position[E_AXIS]);
 						}
 					}else{						
@@ -16327,7 +16425,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							planner.flow_percentage[active_extruder] = 100;
 							planner.refresh_e_factor(active_extruder);
 							COPY(fanSpeeds,fanSpeeds_raft);
-							current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+							current_position[E_AXIS]-=retract_printer_factor;
 							planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 							planner.synchronize();
 							current_position[Z_AXIS] = 5;
@@ -16340,7 +16438,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							//DUAL PROTOCOL
 							dual_mode_mirror_extruder_parked(true);/*true*/
 							Flag_Raft_Dual_Mode_On = true;
-							current_position[E_AXIS] = -(RETRACT_PRINTER_FACTOR);
+							current_position[E_AXIS] = -(retract_printer_factor);
 							planner.set_e_position_mm(current_position[E_AXIS]);
 						}
 					}else{
@@ -16360,7 +16458,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							planner.flow_percentage[active_extruder] = 100;
 							planner.refresh_e_factor(active_extruder);
 							COPY(fanSpeeds,fanSpeeds_raft);
-							current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+							current_position[E_AXIS]-=retract_printer_factor;
 							planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 							planner.synchronize();
 							current_position[Z_AXIS] = 5;
@@ -16375,7 +16473,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 							//DUAL PROTOCOL
 							dual_mode_mirror_extruder_parked(true);/*true*/
 							Flag_Raft_Dual_Mode_On = true;
-							current_position[E_AXIS] = -(RETRACT_PRINTER_FACTOR);
+							current_position[E_AXIS] = -(retract_printer_factor);
 							planner.set_e_position_mm(current_position[E_AXIS]);
 						}
 					}else{
@@ -16519,7 +16617,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 		unsigned long codenum; //throw away variable
 		
 		motorMode = motordriver_mode::motorduplication;	
-		current_position[E_AXIS]+=PURGE_PRINTER_FACTOR;
+		current_position[E_AXIS]+=purge_printer_factor;
 		planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(50.0f), active_extruder);//Retract
 		buffer_line_to_current_position();//Purge
 		
@@ -16532,7 +16630,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 			
 		}
 		
-		current_position[E_AXIS]-=RETRACT_PRINTER_FACTOR;
+		current_position[E_AXIS]-=retract_printer_factor;
 		planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(RETRACT_SPEED_PRINT_TEST), active_extruder);//Retract
 		planner.synchronize();
 		motorMode = motordriver_mode::motordefault;	

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11794,6 +11794,10 @@ inline void gcode_M226() {
 			uint16_t sensorId = parser.intval('X');
 			thermalManager.update_bed_ttbl(sensorId);
 	   }
+	   else if (parser.seen('C') && parser.seen('X')){
+		   uint16_t sensorId = parser.intval('X');
+		   thermalManager.update_chamber_ttbl(sensorId);
+	   }
 	   else{
 		   thermalManager.report_sensors_names();
 	   }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -383,7 +383,7 @@
 
 bool Running = true;
 
-uint8_t marlin_debug_flags = DEBUG_NONE;
+uint8_t marlin_debug_flags = DEBUG_LEVELING;
 
 /**
  * Cartesian Tracking Position gcode Coords from print job
@@ -783,6 +783,7 @@ FORCE_INLINE signed char pgm_read_any(const signed char *p) { return pgm_read_by
 
 #define XYZ_CONSTS_FROM_CONFIG(type, array, CONFIG) \
   static type array##_P[XYZ] = { X_##CONFIG, Y_##CONFIG, Z_##CONFIG }; \
+  __attribute__((unused)) static void set_##array(const AxisEnum axis, type value) { array##_P[axis] = value; } \
   static inline type array(const AxisEnum axis) { return array##_P[axis]; } \
   typedef void __void_##CONFIG##__
 
@@ -11521,79 +11522,64 @@ inline void gcode_M226() {
 	   bool setMinimumTravel = parser.boolval('S', false);
 	   if (parser.seen('X') || parser.seen('Y') || parser.seen('Z'))
 	   {
-		   if (parser.seen('X')){
-			   float distanceAxisX = parser.floatval('X');
+		   if (parser.seen('X')) {
+			   const float distanceAxisX = parser.floatval('X');
 			   if (setMinimumTravel){
-				   base_min_pos_P[X_AXIS] = distanceAxisX;
+				   set_base_min_pos(X_AXIS, distanceAxisX);
 			   }
 			   else {
-				   base_max_pos_P[X_AXIS] = distanceAxisX;
-				}
-				update_software_endstops(X_AXIS);   
+				   set_base_max_pos(X_AXIS, distanceAxisX);
+			   }
+			   soft_endstop_min[X_AXIS] = base_min_pos(X_AXIS);
+			   soft_endstop_max[X_AXIS] = base_max_pos(X_AXIS);
 		   }
-		   if (parser.seen('Y')){
-			   float distanceAxisY = parser.floatval('Y');
+		   if (parser.seen('Y')) {
+			   const float distanceAxisY = parser.floatval('Y');
 			   if (setMinimumTravel){
-				   base_min_pos_P[Y_AXIS] = distanceAxisY;
+				   set_base_min_pos(Y_AXIS, distanceAxisY);
 			   }
 			   else {
-				   base_max_pos_P[Y_AXIS] = distanceAxisY;
+				   set_base_max_pos(Y_AXIS, distanceAxisY);
 			   }
-			   update_software_endstops(Y_AXIS);
+			   soft_endstop_min[Y_AXIS] = base_min_pos(Y_AXIS);
+			   soft_endstop_max[Y_AXIS] = base_max_pos(Y_AXIS);
 		   }
-		   if (parser.seen('Z')){
-			   float distanceAxisZ = parser.floatval('Z');
+		   if (parser.seen('Z')) {
+			   const float distanceAxisZ = parser.floatval('Z');
 			   if (setMinimumTravel){
-				   base_min_pos_P[Z_AXIS] = distanceAxisZ;
+				   set_base_min_pos(Z_AXIS, distanceAxisZ);
 			   }
 			   else {
-				   base_max_pos_P[Z_AXIS] = distanceAxisZ;
-				   }
+				   set_base_max_pos(Z_AXIS, distanceAxisZ);
 			   }
-			   update_software_endstops(Z_AXIS);
-		   }
-		   else{		
-			   SERIAL_ECHO_START();
-			   SERIAL_ECHO("Min Axis Travel X: ");
-			   SERIAL_ECHO(base_min_pos_P[X_AXIS]);
-			   SERIAL_ECHO("\n");
-			   SERIAL_ECHO("Max Axis Travel X: ");
-			   SERIAL_ECHO(base_max_pos_P[X_AXIS]);
-			   SERIAL_ECHO("\n");
-			   SERIAL_ECHO("Min Axis Travel Y: ");
-			   SERIAL_ECHO(base_min_pos_P[Y_AXIS]);
-			   SERIAL_ECHO("\n");
-			   SERIAL_ECHO("Max Axis Travel Y: ");
-			   SERIAL_ECHO(base_max_pos_P[Y_AXIS]);
-			   SERIAL_ECHO("\n");
-			   SERIAL_ECHO("Min Axis Travel Z: ");
-			   SERIAL_ECHO(base_min_pos_P[Z_AXIS]);
-			   SERIAL_ECHO("\n");
-			   SERIAL_ECHO("Max Axis Travel Z: ");
-			   SERIAL_ECHO(base_max_pos_P[Z_AXIS]);
-			   SERIAL_ECHO("\n");	   
-		   }
+			   soft_endstop_min[Z_AXIS] = base_min_pos(Z_AXIS);
+			   soft_endstop_max[Z_AXIS] = base_max_pos(Z_AXIS);
+		   }			   
+		}
+		else{
+			SERIAL_ECHO_START();
+			SERIAL_ECHOLNPAIR("Min Axis Travel X: ", base_min_pos(X_AXIS));
+			SERIAL_ECHOLNPAIR("Max Axis Travel X: ", base_max_pos(X_AXIS));
+			SERIAL_ECHOLNPAIR("Min Axis Travel Y: ", base_min_pos(Y_AXIS));
+			SERIAL_ECHOLNPAIR("Max Axis Travel Y: ", base_max_pos(Y_AXIS));
+			SERIAL_ECHOLNPAIR("Min Axis Travel Z: ", base_min_pos(Z_AXIS));
+			SERIAL_ECHOLNPAIR("Max Axis Travel Z: ", base_max_pos(Z_AXIS));
+		}
    }
    inline void gcode_282() {
 	   if(parser.seen('X')||parser.seen('Y')){
 		   
 		   if(parser.seen('X')){
 			   xBedSize = parser.floatval('X');
-			   update_software_endstops(X_AXIS);
 		   }
 		   if(parser.seen('Y')){
 			   yBedSize = parser.floatval('Y');
-			   update_software_endstops(Y_AXIS);
 		   }
 	   }
 	   else{
 		   SERIAL_ECHO_START();
-		   SERIAL_ECHO("Bed Size X: ");
-		   SERIAL_ECHO(X_BED_SIZE);
-		   SERIAL_ECHO("\n");
-		   SERIAL_ECHO("Bed Size Y: ");
-		   SERIAL_ECHO(Y_BED_SIZE);
-		   SERIAL_ECHO("\n");   
+		   SERIAL_ECHOLNPAIR("Bed Size X: ", X_BED_SIZE);
+		   SERIAL_ECHOLNPAIR("Bed Size Y: ", Y_BED_SIZE);
 	   }
 	   
    }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -618,10 +618,15 @@ _UNUSED static float x_probe_left_extr[3] = {X_SIGMA_PROBE_1_LEFT_EXTR, X_SIGMA_
 _UNUSED static float y_probe_left_extr[3] = {Y_SIGMA_PROBE_1_LEFT_EXTR, Y_SIGMA_PROBE_2_LEFT_EXTR, Y_SIGMA_PROBE_3_LEFT_EXTR};
 _UNUSED static float x_probe_right_extr[3] = {X_SIGMA_PROBE_1_RIGHT_EXTR, X_SIGMA_PROBE_2_RIGHT_EXTR, X_SIGMA_PROBE_3_RIGHT_EXTR};
 _UNUSED static float y_probe_right_extr[3] = {Y_SIGMA_PROBE_1_RIGHT_EXTR, Y_SIGMA_PROBE_2_RIGHT_EXTR, Y_SIGMA_PROBE_3_RIGHT_EXTR};
-	
+
+//Gap bed leveling	
 _UNUSED static float x_gap_avoid_collision_l = X_GAP_AVOID_COLLISION_LEFT;
 _UNUSED static float x_gap_avoid_collision_r = X_GAP_AVOID_COLLISION_RIGHT;
 
+//Print settings
+_UNUSED static float retract_printer_factor = 8;
+_UNUSED static float retract_print_test_factor = 8;
+_UNUSED static float purge_printer_factor = 20;
 
 #endif
 
@@ -11750,6 +11755,23 @@ inline void gcode_M226() {
 		   SERIAL_ECHOLNPAIR("Collision Avoidance R: ", x_gap_avoid_collision_r);
 	   }
    }
+   /*
+	* M287: Set printing settings                                                            
+	*/
+   inline void gcode_M287() {
+	   if(parser.seen('R') && parser.seen('F') && parser.seen('P')) {
+			retract_printer_factor = parser.floatval('R');
+			retract_print_test_factor = parser.floatval('F');
+			purge_printer_factor = parser.floatval('P');	
+	   }
+	   else{
+		   SERIAL_ECHO_START();
+		   SERIAL_ECHOLNPAIR("RETRACT_PRINTER_FACTOR: ", retract_printer_factor);
+		   SERIAL_ECHOLNPAIR("RETRACT_PRINT_TEST_FACTOR: ", retract_print_test_factor);
+		   SERIAL_ECHOLNPAIR("PURGE_PRINTER_FACTOR: ", purge_printer_factor);
+	   }
+   }
+   
    
    
 #if HAS_BUZZER
@@ -14801,6 +14823,7 @@ void process_parsed_command() {
 		case 284: gcode_M284(); break;							  // M284: Set knob position
 		case 285: gcode_M285(); break;							  // M285: Set probe position
 		case 286: gcode_M286(); break;							  // M286: Collision avoidance bed leveling
+		case 287: gcode_M287(); break;							  // M287: Set printing settings
 		
       #if ENABLED(BABYSTEPPING)
         case 290: gcode_M290(); break;                            // M290: Babystepping

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -949,7 +949,7 @@ inline bool _enqueuecommand(const char* cmd, bool say_ok=false) {
 /**
  * Enqueue with Serial Echo
  */
-bool enqueue_and_echo_command(const char* cmd, bool say_ok=false) {
+bool enqueue_and_echo_command(const char* cmd, bool say_ok) {
   if (_enqueuecommand(cmd, say_ok)) {
     SERIAL_ECHO_START();
     SERIAL_ECHOPAIR(MSG_ENQUEUEING, cmd);
@@ -1067,7 +1067,7 @@ void gcode_line_error(const char* err, bool doFlush = true) {
  */
 #if defined(BCN3D_MOD)
 DiscardSerialReason discard_serial = DiscardSerialReason::NONE;
-#define NOTIFY_SERIAL_COMMAND_QUEUE_EMPTY
+//#define NOTIFY_SERIAL_COMMAND_QUEUE_EMPTY
 #endif
 
 inline void get_serial_commands() {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8048,7 +8048,8 @@ inline void gcode_M141() { // Set chamber temperature
 
 inline void gcode_M668() {
 	planner.synchronize();
-
+	gcode_LastN = tracking_lastgcode - 1;
+	
 	SERIAL_PROTOCOLPGM("Stored Position");
 	SERIAL_PROTOCOLPGM(" X:");
 	MYSERIAL0.print(tracking_position[X_AXIS],3);
@@ -16680,8 +16681,6 @@ void execPauseFromSerial() {
 			
 	clear_command_queue(); // clear marlin queue
 	discard_serial = DiscardSerialReason::PAUSE; // Release the flag once Serial buffer is Empty
-	//enqueue_and_echo_command("M668");
-	gcode_LastN = tracking_lastgcode - 1;	
 }
 
 /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11617,13 +11617,15 @@ inline void gcode_M226() {
 	*/
    inline void gcode_M282() {
 	   if(parser.seen('X') && parser.seen('Y')){		   
-			xBedSize = parser.floatval('X');
+			xBedSize = parser.floatval('X');			
 			yBedSize = parser.floatval('Y');
+			duplicate_extruder_x_offset = xBedSize/2.0;
 	   }
 	   else{
 		   SERIAL_ECHO_START();
 		   SERIAL_ECHOLNPAIR("Bed Size X: ", xBedSize);
 		   SERIAL_ECHOLNPAIR("Bed Size Y: ", yBedSize);
+		   SERIAL_ECHOLNPAIR("Duplication Offset: ", duplicate_extruder_x_offset);
 	   }	   
    }
    /*

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11783,7 +11783,7 @@ inline void gcode_M226() {
    */
    inline void gcode_M305() {
 	   if (parser.seen('P') && parser.seen('X')) {
-			uint8_t index = parser.intval('P');
+			int8_t index = parser.intval('P');
 			uint16_t sensorId = parser.intval('X');
 			if (index < HOTENDS ){
 				thermalManager.update_heater_ttbl_map(index, sensorId);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -383,7 +383,7 @@
 
 bool Running = true;
 
-uint8_t marlin_debug_flags = DEBUG_LEVELING;
+uint8_t marlin_debug_flags = DEBUG_NONE;
 
 /**
  * Cartesian Tracking Position gcode Coords from print job
@@ -591,6 +591,33 @@ int16_t fanSpeeds_raft[FAN_COUNT] = { 0 };
 static DualXMode dual_x_carriage_mode = DEFAULT_DUAL_X_CARRIAGE_MODE;
 
 bool waiting_resend_confirmation = false;
+
+#endif
+
+#if defined(BCN3D_MOD)
+//Configuration Overlay
+
+#if ENABLED(Z_SAFE_HOMING)
+
+#endif
+
+//Bed size
+_UNUSED	static float xBedSize = 420;
+_UNUSED	static float yBedSize = 300;
+
+//Know positions
+_UNUSED static float x_screw_bed_calib_1 = (X1_MIN_POS + 262.9);
+_UNUSED static float y_screw_bed_calib_1 = (Y_MAX_POS + 30.3);
+_UNUSED static float x_screw_bed_calib_2 = (X1_MIN_POS + 54.4);
+_UNUSED static float y_screw_bed_calib_2 = (Y_MAX_POS - 297.2);
+_UNUSED static float x_screw_bed_calib_3 = (X1_MIN_POS + 471.4);
+_UNUSED static float y_screw_bed_calib_3 = (Y_MAX_POS - 297.2);
+
+//Probe positions
+_UNUSED static float x_probe_left_extr[3] = {X_SIGMA_PROBE_1_LEFT_EXTR, X_SIGMA_PROBE_2_LEFT_EXTR, X_SIGMA_PROBE_3_LEFT_EXTR};
+_UNUSED static float y_probe_left_extr[3] = {Y_SIGMA_PROBE_1_LEFT_EXTR, Y_SIGMA_PROBE_2_LEFT_EXTR, Y_SIGMA_PROBE_3_LEFT_EXTR};
+_UNUSED static float x_probe_right_extr[3] = {X_SIGMA_PROBE_1_RIGHT_EXTR, X_SIGMA_PROBE_2_RIGHT_EXTR, X_SIGMA_PROBE_3_RIGHT_EXTR};
+_UNUSED static float y_probe_right_extr[3] = {Y_SIGMA_PROBE_1_RIGHT_EXTR, Y_SIGMA_PROBE_2_RIGHT_EXTR, Y_SIGMA_PROBE_3_RIGHT_EXTR};
 
 #endif
 
@@ -11644,6 +11671,8 @@ inline void gcode_M226() {
 	* M285: Set probe position. X and Y coords                                                               
 	*/
    inline void gcode_M285() {
+	   
+	   // M285 E0 P1 X2 Y200; M285 E0 P2 X2 Y10; M285 E0 P3 X300 Y10 |||| M285 E1 P1 X300 Y200; M285 E1 P2 X300 Y10; M285 E1 P3 X2 Y10
 	   
 	   const float x_coords = parser.floatval('X');
 	   const float y_coords = parser.floatval('Y');

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1094,12 +1094,11 @@ void servo_init() {
 
 #endif
 
-void gcode_line_error(const char* err, bool doFlush = true) {
+void gcode_line_error(const char* err) {
   SERIAL_ERROR_START();
   serialprintPGM(err);
   SERIAL_ERRORLN(gcode_LastN);
-  //Serial.println(gcode_N);
-  if (doFlush) flush_and_request_resend();
+  flush_and_request_resend();
   serial_count = 0;
 }
 
@@ -1119,6 +1118,7 @@ inline void get_serial_commands() {
   static int raft_indicator_is_Gcode = 0;
   static float current_z_raft_seen = 0.0;
   static uint32_t fileraftstart = 0;
+  static uint16_t skipped_bytes_waiting_resend = 0;
   #if defined(NOTIFY_SERIAL_COMMAND_QUEUE_EMPTY)
   static bool notified_empty_queue = true;
   #endif
@@ -1172,7 +1172,6 @@ inline void get_serial_commands() {
       if (!serial_count) { thermalManager.manage_heater(); continue; }
 
       serial_line_buffer[serial_count] = 0;             // Terminate string
-      serial_count = 0;                                 // Reset buffer
 
       char* command = serial_line_buffer;
 
@@ -1191,10 +1190,18 @@ inline void get_serial_commands() {
         gcode_N = strtol(npos + 1, NULL, 10);
 
         #if defined(BCN3D_MOD)
-        if (waiting_resend_confirmation && gcode_N != gcode_LastN + 1) {
-          continue; // Ignore commands when waiting for resend confirmation
-        } else if (waiting_resend_confirmation) {
-          waiting_resend_confirmation = false; // When the correct line is sent, consider it the resend confirmation
+        // All the commands that don't match the expected line will be discarted after a resend is requested.
+        // The maximum discarted commands is two times the serial receive buffer
+        if (waiting_resend_confirmation && gcode_N != gcode_LastN + 1 && 
+            skipped_bytes_waiting_resend < RX_BUFFER_SIZE * 2) {
+          skipped_bytes_waiting_resend += serial_count;
+          serial_count = 0; // Reset buffer
+          continue;
+        }
+        // When the correct line is sent, consider it the resend confirmation
+        else if (waiting_resend_confirmation) {
+          skipped_bytes_waiting_resend = 0;
+          waiting_resend_confirmation = false;
         }
         #endif
 
@@ -1218,6 +1225,8 @@ inline void get_serial_commands() {
           return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM));
       #endif
 	  
+      serial_count = 0; // Reset buffer
+
       #if defined(BCN3D_MOD)
 		
       switch(dual_x_carriage_mode){
@@ -1366,7 +1375,6 @@ inline void get_serial_commands() {
 						  raft_line_counter_g = 1;
 						  raft_line_counter = 1;
 					  }
-					  
 				  }
 			  }
 		  }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7895,7 +7895,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	SERIAL_PROTOCOLLN(current_position[Z_AXIS]);
 
 	setup_for_endstop_or_probe_move();
-	float z_at_pt_1 = probe_pt(X_SIGMA_PROBE_1_LEFT_EXTR,Y_SIGMA_PROBE_1_LEFT_EXTR, PROBE_PT_RAISE, 3);
+	float z_at_pt_1 = probe_pt(x_probe_left_extr[0],y_probe_left_extr[0], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	
 	feedrate_mm_s = XY_PROBE_FEEDRATE_MM_S;
@@ -7905,10 +7905,10 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], XY_PROBE_FEEDRATE_MM_S, 1);
 
 	setup_for_endstop_or_probe_move();
-	float z_at_pt_2 = probe_pt(X_SIGMA_PROBE_2_LEFT_EXTR,Y_SIGMA_PROBE_2_LEFT_EXTR, PROBE_PT_RAISE, 3);
+	float z_at_pt_2 = probe_pt(x_probe_left_extr[1],y_probe_left_extr[1], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	setup_for_endstop_or_probe_move();
-	float z_at_pt_3 = probe_pt(X_SIGMA_PROBE_3_LEFT_EXTR,Y_SIGMA_PROBE_3_LEFT_EXTR, PROBE_PT_RAISE, 3);
+	float z_at_pt_3 = probe_pt(x_probe_left_extr[2],y_probe_left_extr[2], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	
 	current_position[Z_AXIS] += Z_RAISE_BET_PROBINGS;
@@ -7930,13 +7930,13 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	//Probe at 3 arbitrary points
 	//probe left extruder
 	setup_for_endstop_or_probe_move();
-	float z2_at_pt_3 = probe_pt(X_SIGMA_PROBE_3_RIGHT_EXTR,Y_SIGMA_PROBE_3_RIGHT_EXTR, PROBE_PT_RAISE, 3);
+	float z2_at_pt_3 = probe_pt(x_probe_right_extr[2], y_probe_right_extr[2], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	
 	feedrate_mm_s = XY_PROBE_FEEDRATE_MM_S;
 		
 	setup_for_endstop_or_probe_move();
-	float z2_at_pt_2 = probe_pt(X_SIGMA_PROBE_2_RIGHT_EXTR,Y_SIGMA_PROBE_2_RIGHT_EXTR, PROBE_PT_RAISE, 3);
+	float z2_at_pt_2 = probe_pt(x_probe_right_extr[1], y_probe_right_extr[1], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	
 	// Move the probe to the starting X
@@ -7944,7 +7944,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(4000), 1);
 	
 	setup_for_endstop_or_probe_move();
-	float z2_at_pt_1 = probe_pt(X_SIGMA_PROBE_1_RIGHT_EXTR,Y_SIGMA_PROBE_1_RIGHT_EXTR, PROBE_PT_RAISE, 3);
+	float z2_at_pt_1 = probe_pt(x_probe_right_extr[0], y_probe_right_extr[0], PROBE_PT_RAISE, 3);
 	clean_up_after_endstop_or_probe_move();
 	
 	
@@ -7965,13 +7965,13 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	plan_bed_level_matrix.set_to_identity();
 	
 	
-	vector_3 pt1_0 = vector_3(X_SIGMA_PROBE_1_LEFT_EXTR, Y_SIGMA_PROBE_1_LEFT_EXTR, z_at_pt_1);
-	vector_3 pt2_0 = vector_3(X_SIGMA_PROBE_2_LEFT_EXTR, Y_SIGMA_PROBE_2_LEFT_EXTR, z_at_pt_2);
-	vector_3 pt3_0 = vector_3(X_SIGMA_PROBE_3_LEFT_EXTR, Y_SIGMA_PROBE_3_LEFT_EXTR, z_at_pt_3);
+	vector_3 pt1_0 = vector_3(x_probe_left_extr[1], y_probe_left_extr[1], z_at_pt_1);
+	vector_3 pt2_0 = vector_3(x_probe_left_extr[2], y_probe_left_extr[2], z_at_pt_2);
+	vector_3 pt3_0 = vector_3(x_probe_left_extr[3], y_probe_left_extr[3], z_at_pt_3);
 	
-	vector_3 pt1_1 = vector_3(X_SIGMA_PROBE_1_RIGHT_EXTR, Y_SIGMA_PROBE_1_RIGHT_EXTR, z2_at_pt_1);
-	vector_3 pt2_1 = vector_3(X_SIGMA_PROBE_2_RIGHT_EXTR, Y_SIGMA_PROBE_2_RIGHT_EXTR, z2_at_pt_2);
-	vector_3 pt3_1 = vector_3(X_SIGMA_PROBE_3_RIGHT_EXTR, Y_SIGMA_PROBE_3_RIGHT_EXTR, z2_at_pt_3);
+	vector_3 pt1_1 = vector_3(x_probe_right_extr[1], y_probe_right_extr[1], z2_at_pt_1);
+	vector_3 pt2_1 = vector_3(x_probe_right_extr[2], y_probe_right_extr[2], z2_at_pt_2);
+	vector_3 pt3_1 = vector_3(x_probe_right_extr[3], y_probe_right_extr[3], z2_at_pt_3);
 	
 	vector_3 from_2_to_1_0 = (pt1_0 - pt2_0);
 	vector_3 from_2_to_3_0 = (pt3_0 - pt2_0);
@@ -7983,16 +7983,16 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	vector_3 planeNormal_1 = vector_3::cross(from_3_to_1_1, from_3_to_2_1); // Point 3 is 2 on the left
 	planeNormal_1 = vector_3(planeNormal_1.x, planeNormal_1.y, planeNormal_1.z);
 	
-	float Zscroll_0=(-planeNormal_0.x*(CARGOL_1_X-X_SIGMA_PROBE_1_LEFT_EXTR-CARGOL_1_X)-planeNormal_0.y*(CARGOL_1_Y-Y_SIGMA_PROBE_3_LEFT_EXTR-CARGOL_1_Y/2.0))/planeNormal_0.z;
-	float Zscroll_1=(-planeNormal_1.x*(CARGOL_1_X-X_SIGMA_PROBE_1_LEFT_EXTR-CARGOL_1_X)-planeNormal_1.y*(CARGOL_1_Y-Y_SIGMA_PROBE_3_LEFT_EXTR-CARGOL_1_Y/2))/planeNormal_1.z;
+	float Zscroll_0=(-planeNormal_0.x*(CARGOL_1_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_0.y*(CARGOL_1_Y-y_probe_left_extr[2]-CARGOL_1_Y/2.0))/planeNormal_0.z;
+	float Zscroll_1=(-planeNormal_1.x*(CARGOL_1_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_1_Y-y_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
 	
 	//float z1_0=(-planeNormal_0.x*0.0-planeNormal_0.y*(Y_SIGMA_PROBE_1_LEFT_EXTR-Y_SIGMA_PROBE_3_LEFT_EXTR))/planeNormal_0.z;
-	float z2_0=(-planeNormal_0.x*(CARGOL_2_X-X_SIGMA_PROBE_1_LEFT_EXTR-CARGOL_1_X)-planeNormal_0.y*(CARGOL_2_Y-Y_SIGMA_PROBE_3_LEFT_EXTR-CARGOL_1_Y/2))/planeNormal_0.z;
-	float z3_0=(-planeNormal_0.x*(CARGOL_3_X-X_SIGMA_PROBE_1_LEFT_EXTR-CARGOL_1_X)-planeNormal_0.y*(CARGOL_3_Y-Y_SIGMA_PROBE_3_LEFT_EXTR-CARGOL_1_Y/2))/planeNormal_0.z;
+	float z2_0=(-planeNormal_0.x*(CARGOL_2_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_0.y*(CARGOL_2_Y-y_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_0.z;
+	float z3_0=(-planeNormal_0.x*(CARGOL_3_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_0.y*(CARGOL_3_Y-y_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_0.z;
 	
 	//float z1_1=(-planeNormal_1.x*(X_SIGMA_PROBE_1_RIGHT_EXTR-X_SIGMA_PROBE_1_LEFT_EXTR)-planeNormal_1.y*(Y_SIGMA_PROBE_1_RIGHT_EXTR-Y_SIGMA_PROBE_3_RIGHT_EXTR))/planeNormal_1.z;
-	float z2_1=(-planeNormal_1.x*(CARGOL_2_X-X_SIGMA_PROBE_1_LEFT_EXTR-CARGOL_1_X)-planeNormal_1.y*(CARGOL_2_Y-Y_SIGMA_PROBE_3_LEFT_EXTR-CARGOL_1_Y/2))/planeNormal_1.z;
-	float z3_1=(-planeNormal_1.x*(CARGOL_3_X-X_SIGMA_PROBE_1_LEFT_EXTR-CARGOL_1_X)-planeNormal_1.y*(CARGOL_3_Y-Y_SIGMA_PROBE_3_LEFT_EXTR-CARGOL_1_Y/2))/planeNormal_1.z;
+	float z2_1=(-planeNormal_1.x*(CARGOL_2_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_2_Y-x_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
+	float z3_1=(-planeNormal_1.x*(CARGOL_3_X-x_probe_left_extr[0]-CARGOL_1_X)-planeNormal_1.y*(CARGOL_3_Y-x_probe_left_extr[2]-CARGOL_1_Y/2))/planeNormal_1.z;
 	
 	//SERIAL_PROTOCOLPGM("planeNormal_0.x: ");
 	//SERIAL_PROTOCOLLN(planeNormal_0.x);
@@ -11566,7 +11566,10 @@ inline void gcode_M226() {
 			SERIAL_ECHOLNPAIR("Max Axis Travel Z: ", base_max_pos(Z_AXIS));
 		}
    }
-   inline void gcode_282() {
+   /*
+	* M282: Set bed size. X and Y                                                                  
+	*/
+   inline void gcode_M282() {
 	   if(parser.seen('X')||parser.seen('Y')){
 		   
 		   if(parser.seen('X')){
@@ -11580,10 +11583,121 @@ inline void gcode_M226() {
 		   SERIAL_ECHO_START();
 		   SERIAL_ECHOLNPAIR("Bed Size X: ", X_BED_SIZE);
 		   SERIAL_ECHOLNPAIR("Bed Size Y: ", Y_BED_SIZE);
-	   }
-	   
+	   }	   
    }
-
+   /*
+	* M283: Set home safe point. X and Y coords                                                               
+	*/
+   inline void gcode_M283() {
+	   if(parser.seen('X')||parser.seen('Y')){
+		   
+		   if(parser.seen('X')){
+			   z_safe_homing_x_point = parser.floatval('X');
+		   }
+		   if(parser.seen('Y')){
+			   z_safe_homing_y_point = parser.floatval('Y');
+		   }
+	   }
+	   else{
+		   SERIAL_ECHO_START();
+		   SERIAL_ECHOLNPAIR("Home safe point X: ", Z_SAFE_HOMING_X_POINT);
+		   SERIAL_ECHOLNPAIR("Home safe point Y: ", Z_SAFE_HOMING_Y_POINT);
+	   }	   
+   }
+   /*
+	* M284: Set knob position. X and Y coords                                                               
+	*/
+   inline void gcode_M284() {
+	   
+	   const float x_coords = parser.floatval('X');
+	   const float y_coords = parser.floatval('Y');
+	   
+	   if(parser.seen('K') && parser.seen('X') && parser.seen('Y')) {
+		   switch(parser.byteval('K')) {
+			   case 1:
+				   x_screw_bed_calib_1 = x_coords;
+				   y_screw_bed_calib_1 = y_coords;
+			   break;
+			   case 2:
+				   x_screw_bed_calib_2 = x_coords;
+				   y_screw_bed_calib_2 = y_coords;			   
+			   break;
+			   case 3:
+				   x_screw_bed_calib_3 = x_coords;
+				   y_screw_bed_calib_3 = y_coords;		   
+			   break;
+			   default:
+			   break;
+		   }
+	   }
+	   else{
+		   SERIAL_ECHO_START();
+		   SERIAL_ECHOLNPAIR("Knob 1 x position: ", CARGOL_1_X);
+		   SERIAL_ECHOLNPAIR("Knob 1 y position: ", CARGOL_1_Y);
+		   SERIAL_ECHOLNPAIR("Knob 2 x position: ", CARGOL_2_X);
+		   SERIAL_ECHOLNPAIR("Knob 2 y position: ", CARGOL_2_Y);
+		   SERIAL_ECHOLNPAIR("Knob 3 x position: ", CARGOL_3_X);
+		   SERIAL_ECHOLNPAIR("Knob 3 y position: ", CARGOL_3_Y);
+	   }	   
+   }
+   /*
+	* M285: Set probe position. X and Y coords                                                               
+	*/
+   inline void gcode_M285() {
+	   
+	   const float x_coords = parser.floatval('X');
+	   const float y_coords = parser.floatval('Y');
+	   
+	   if(parser.seen('P') && parser.seen('X') && parser.seen('Y') && parser.seen('E')) {
+		   if(parser.byteval('E') == 0) {
+			    switch(parser.byteval('P')) {
+				    case 1:
+				    x_probe_left_extr[0] = x_coords;
+				    y_probe_left_extr[0] = y_coords;
+				    break;
+				    case 2:
+				    x_probe_left_extr[1] = x_coords;
+				    y_probe_left_extr[1] = y_coords;
+				    break;
+				    case 3:
+				    x_probe_left_extr[2] = x_coords;
+				    y_probe_left_extr[2] = y_coords;
+				    break;
+				    default:
+				    break;
+			    }			   
+		   } 
+		   else if(parser.byteval('E') == 1) {
+			    switch(parser.byteval('P')) {
+				    case 1:
+				    x_probe_right_extr[0] = x_coords;
+				    y_probe_right_extr[0] = y_coords;
+				    break;
+				    case 2:
+				    x_probe_right_extr[1] = x_coords;
+				    y_probe_right_extr[1] = y_coords;
+				    break;
+				    case 3:
+				    x_probe_right_extr[2] = x_coords;
+				    y_probe_right_extr[2] = y_coords;
+				    break;
+				    default:
+				    break;
+			    }
+		   }		  
+	   }
+	   else{
+		   SERIAL_ECHO_START();
+		   SERIAL_ECHOLNPGM("Left Probe:");
+		   SERIAL_ECHOPAIR("Probe 1 x: ", x_probe_left_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[0]);
+		   SERIAL_ECHOPAIR("Probe 2 x: ", x_probe_left_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[1]);
+		   SERIAL_ECHOPAIR("Probe 3 x: ", x_probe_left_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_left_extr[2]);
+		   SERIAL_ECHOLNPGM("Right Probe:");
+		   SERIAL_ECHOPAIR("Probe 1 x: ", x_probe_right_extr[0]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[0]);
+		   SERIAL_ECHOPAIR("Probe 2 x: ", x_probe_right_extr[1]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[1]);
+		   SERIAL_ECHOPAIR("Probe 3 x: ", x_probe_right_extr[2]); SERIAL_ECHOLNPAIR(" y: ", y_probe_right_extr[2]);
+	   }	   
+   }
 #if HAS_BUZZER
 
   /**
@@ -14628,6 +14742,10 @@ void process_parsed_command() {
       #endif
 	  
 		case 281: gcode_M281(); break;							  // M281: Set Axis Maximum Travel
+		case 282: gcode_M282(); break;							  // M282: Set bed size
+		case 283: gcode_M283(); break;							  // M283: Set home safe point
+		case 284: gcode_M284(); break;							  // M284: Set knob position
+		case 285: gcode_M285(); break;							  // M285: Set probe position
 		
       #if ENABLED(BABYSTEPPING)
         case 290: gcode_M290(); break;                            // M290: Babystepping

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -375,8 +375,8 @@
 /**
  * Validate that the bed size fits
  */
-static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
-  "Movement bounds ([XY]_MIN_POS, [XY]_MAX_POS) are too narrow to contain [XY]_BED_SIZE.");
+//static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
+  //"Movement bounds ([XY]_MIN_POS, [XY]_MAX_POS) are too narrow to contain [XY]_BED_SIZE.");
 
 /**
  * Granular software endstops (Marlin >= 1.1.7)
@@ -896,12 +896,12 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
  */
 
 #if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(AUTO_BED_LEVELING_3POINT)
-  static_assert(WITHIN(PROBE_PT_1_X, MIN_PROBE_X, MAX_PROBE_X), "PROBE_PT_1_X is outside the probe region.");
-  static_assert(WITHIN(PROBE_PT_2_X, MIN_PROBE_X, MAX_PROBE_X), "PROBE_PT_2_X is outside the probe region.");
-  static_assert(WITHIN(PROBE_PT_3_X, MIN_PROBE_X, MAX_PROBE_X), "PROBE_PT_3_X is outside the probe region.");
-  static_assert(WITHIN(PROBE_PT_1_Y, MIN_PROBE_Y, MAX_PROBE_Y), "PROBE_PT_1_Y is outside the probe region.");
-  static_assert(WITHIN(PROBE_PT_2_Y, MIN_PROBE_Y, MAX_PROBE_Y), "PROBE_PT_2_Y is outside the probe region.");
-  static_assert(WITHIN(PROBE_PT_3_Y, MIN_PROBE_Y, MAX_PROBE_Y), "PROBE_PT_3_Y is outside the probe region.");
+  //static_assert(WITHIN(PROBE_PT_1_X, MIN_PROBE_X, MAX_PROBE_X), "PROBE_PT_1_X is outside the probe region.");
+  //static_assert(WITHIN(PROBE_PT_2_X, MIN_PROBE_X, MAX_PROBE_X), "PROBE_PT_2_X is outside the probe region.");
+  //static_assert(WITHIN(PROBE_PT_3_X, MIN_PROBE_X, MAX_PROBE_X), "PROBE_PT_3_X is outside the probe region.");
+  //static_assert(WITHIN(PROBE_PT_1_Y, MIN_PROBE_Y, MAX_PROBE_Y), "PROBE_PT_1_Y is outside the probe region.");
+  //static_assert(WITHIN(PROBE_PT_2_Y, MIN_PROBE_Y, MAX_PROBE_Y), "PROBE_PT_2_Y is outside the probe region.");
+  //static_assert(WITHIN(PROBE_PT_3_Y, MIN_PROBE_Y, MAX_PROBE_Y), "PROBE_PT_3_Y is outside the probe region.");
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -1007,14 +1007,15 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
  * Make sure Z_SAFE_HOMING point is reachable
  */
 #if ENABLED(Z_SAFE_HOMING)
-  #if HAS_BED_PROBE
-    static_assert(WITHIN(Z_SAFE_HOMING_X_POINT, MIN_PROBE_X, MAX_PROBE_X), "Z_SAFE_HOMING_X_POINT is outside the probe region.");
-    static_assert(WITHIN(Z_SAFE_HOMING_Y_POINT, MIN_PROBE_Y, MAX_PROBE_Y), "Z_SAFE_HOMING_Y_POINT is outside the probe region.");
-  #else
-    static_assert(WITHIN(Z_SAFE_HOMING_X_POINT, X_MIN_POS, X_MAX_POS), "Z_SAFE_HOMING_X_POINT can't be reached by the nozzle.");
-    static_assert(WITHIN(Z_SAFE_HOMING_Y_POINT, Y_MIN_POS, Y_MAX_POS), "Z_SAFE_HOMING_Y_POINT can't be reached by the nozzle.");
-  #endif
+  //#if HAS_BED_PROBE
+    //static_assert(WITHIN(Z_SAFE_HOMING_X_POINT, MIN_PROBE_X, MAX_PROBE_X), "Z_SAFE_HOMING_X_POINT is outside the probe region.");
+    //static_assert(WITHIN(Z_SAFE_HOMING_Y_POINT, MIN_PROBE_Y, MAX_PROBE_Y), "Z_SAFE_HOMING_Y_POINT is outside the probe region.");
+  //#else
+    //static_assert(WITHIN(Z_SAFE_HOMING_X_POINT, X_MIN_POS, X_MAX_POS), "Z_SAFE_HOMING_X_POINT can't be reached by the nozzle.");
+    //static_assert(WITHIN(Z_SAFE_HOMING_Y_POINT, Y_MIN_POS, Y_MAX_POS), "Z_SAFE_HOMING_Y_POINT can't be reached by the nozzle.");
+  //#endif
 #endif // Z_SAFE_HOMING
+
 
 /**
  * Make sure DISABLE_[XYZ] compatible with selected homing options

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -35,7 +35,7 @@
   /**
    * Marlin release version identifier
    */
-  #define SHORT_BUILD_VERSION "v0.5.2" 
+  #define SHORT_BUILD_VERSION "v0.5.3RC1" 
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -48,7 +48,7 @@
    * here we define this default string as the date where the latest release
    * version was tagged.
    */
-  #define STRING_DISTRIBUTION_DATE "2020-02-14"
+  #define STRING_DISTRIBUTION_DATE "2020-03-11"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC15"
+  #define SHORT_BUILD_VERSION "v0.6.1"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-04-22"
+  #define STRING_DISTRIBUTION_DATE "2020-06-11"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC13"
+  #define SHORT_BUILD_VERSION "v0.6.1RC14"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-04-06"
+  #define STRING_DISTRIBUTION_DATE "2020-04-22"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC9"
+  #define SHORT_BUILD_VERSION "v0.6.1RC10"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-03-17"
+  #define STRING_DISTRIBUTION_DATE "2020-03-23"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC8"
+  #define SHORT_BUILD_VERSION "v0.6.1RC9"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-03-11"
+  #define STRING_DISTRIBUTION_DATE "2020-03-17"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC2"
+  #define SHORT_BUILD_VERSION "v0.6.1RC8" 
 		
   /**
    * Verbose version identifier which should contain a reference to the location

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC18"
+  #define SHORT_BUILD_VERSION "v0.6.1RC13"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-04-01"
+  #define STRING_DISTRIBUTION_DATE "2020-04-06"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC10"
+  #define SHORT_BUILD_VERSION "v0.6.1RC11"
 		
   /**
    * Verbose version identifier which should contain a reference to the location

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC11"
+  #define SHORT_BUILD_VERSION "v0.6.1RC18"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-03-23"
+  #define STRING_DISTRIBUTION_DATE "2020-04-01"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.
@@ -72,7 +72,7 @@
   /**
    * Defines a generic printer name to be output to the LCD after booting Marlin.
    */
-  #define MACHINE_NAME "BCN3D Epsilon"
+  #define MACHINE_NAME "BCN3D Printer"
 
   /**
    * The SOURCE_CODE_URL is the location where users will find the Marlin Source

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -35,7 +35,8 @@
   /**
    * Marlin release version identifier
    */
-  #define SHORT_BUILD_VERSION "v0.5.3RC1" 
+
+  #define SHORT_BUILD_VERSION "v0.6.1RC2"
 		
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -48,6 +49,7 @@
    * here we define this default string as the date where the latest release
    * version was tagged.
    */
+
   #define STRING_DISTRIBUTION_DATE "2020-03-11"
 
   /**

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC8" 
+  #define SHORT_BUILD_VERSION "v0.6.1RC8"
 		
   /**
    * Verbose version identifier which should contain a reference to the location

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.6.1RC14"
+  #define SHORT_BUILD_VERSION "v0.6.1RC15"
 		
   /**
    * Verbose version identifier which should contain a reference to the location

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -78,20 +78,8 @@
 #define X_SIGMA_PROBE_3_RIGHT_EXTR	 X_SIGMA_PROBE_2_LEFT_EXTR
 #define Y_SIGMA_PROBE_3_RIGHT_EXTR	 Y_SIGMA_PROBE_2_LEFT_EXTR
 
-__attribute__((unused)) static float x_probe_left_extr[3] = {X_SIGMA_PROBE_1_LEFT_EXTR, X_SIGMA_PROBE_2_LEFT_EXTR, X_SIGMA_PROBE_3_LEFT_EXTR};
-__attribute__((unused)) static float y_probe_left_extr[3] = {Y_SIGMA_PROBE_1_LEFT_EXTR, Y_SIGMA_PROBE_2_LEFT_EXTR, Y_SIGMA_PROBE_3_LEFT_EXTR};
-__attribute__((unused)) static float x_probe_right_extr[3] = {X_SIGMA_PROBE_1_RIGHT_EXTR, X_SIGMA_PROBE_2_RIGHT_EXTR, X_SIGMA_PROBE_3_RIGHT_EXTR};
-__attribute__((unused)) static float y_probe_right_extr[3] = {Y_SIGMA_PROBE_1_RIGHT_EXTR, Y_SIGMA_PROBE_2_RIGHT_EXTR, Y_SIGMA_PROBE_3_RIGHT_EXTR};
-
 #define X_GAP_AVOID_COLLISION_LEFT	(13.2)
 #define X_GAP_AVOID_COLLISION_RIGHT	(12.7)
-
-__attribute__((unused)) static float x_screw_bed_calib_1 = (X1_MIN_POS + 262.9);
-__attribute__((unused)) static float y_screw_bed_calib_1 = (Y_MAX_POS + 30.3);
-__attribute__((unused)) static float x_screw_bed_calib_2 = (X1_MIN_POS + 54.4);
-__attribute__((unused)) static float y_screw_bed_calib_2 = (Y_MAX_POS - 297.2);
-__attribute__((unused)) static float x_screw_bed_calib_3 = (X1_MIN_POS + 471.4);
-__attribute__((unused)) static float y_screw_bed_calib_3 = (Y_MAX_POS - 297.2);
 
 #define CARGOL_1_X  x_screw_bed_calib_1
 #define CARGOL_1_Y  y_screw_bed_calib_1

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -8,7 +8,7 @@
 
 #define BCN3D_MOD
 
-#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
+//#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
 #ifdef BCN3D_PRINT_SIMULATION
 	#define SIMULATION_TEMP_AMB							22.5
 #endif

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -8,7 +8,7 @@
 
 #define BCN3D_MOD
 
-//#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
+#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
 #ifdef BCN3D_PRINT_SIMULATION
 	#define SIMULATION_TEMP_AMB							22.5
 #endif
@@ -18,11 +18,9 @@
 #define RAFT_Z_THRESHOLD 0.05
 //	END DUAL MODE SETTINGS
 
-
-#define RETRACT_PRINTER_FACTOR			 retract_printer_factor				//(mm)
-#define RETRACT_PRINT_TEST_FACTOR		 retract_print_test_factor			//(mm)
-#define PURGE_PRINTER_FACTOR			 purge_printer_factor				//(mm)
-
+#define RETRACT_PRINTER_FACTOR			 8			//(mm)
+#define RETRACT_PRINT_TEST_FACTOR		 8			//(mm)
+#define PURGE_PRINTER_FACTOR			 20			//(mm)
 
 //RETRACT SETTINGS
 
@@ -71,14 +69,20 @@
 #define X_GAP_AVOID_COLLISION_LEFT	(13.2)
 #define X_GAP_AVOID_COLLISION_RIGHT	(12.7)
 
-#define CARGOL_1_X  x_screw_bed_calib_1
-#define CARGOL_1_Y  y_screw_bed_calib_1
+//#define CARGOL_1_X  x_screw_bed_calib_1
+#define SCREW_BED_1_X (X1_MIN_POS + 262.9)
+//#define CARGOL_1_Y  y_screw_bed_calib_1
+#define SCREW_BED_1_Y (Y_MAX_POS + 30.3)
 
-#define CARGOL_2_X  x_screw_bed_calib_2
-#define CARGOL_2_Y  y_screw_bed_calib_2
+//#define CARGOL_2_X  x_screw_bed_calib_2
+#define SCREW_BED_2_X (X1_MIN_POS + 54.4)
+//#define CARGOL_2_Y  y_screw_bed_calib_2
+#define SCREW_BED_2_Y (Y_MAX_POS - 297.2)
 
-#define CARGOL_3_X  x_screw_bed_calib_3
-#define CARGOL_3_Y  y_screw_bed_calib_3
+//#define CARGOL_3_X  x_screw_bed_calib_3
+#define SCREW_BED_3_X (X1_MIN_POS + 471.4)
+//#define CARGOL_3_Y  y_screw_bed_calib_3
+#define SCREW_BED_3_Y (Y_MAX_POS - 297.2)
 
 #define DEFAULT_DUPLICATION_X_OFFSET 210
 

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -54,60 +54,7 @@
 #define LINES_LAYER_HEIGHT_XY 0.2
 #define DRAW_LINE_SPEED		1500.0
 
-#if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_SIGMA
-//Left extruder probe point
-#define X_SIGMA_PROBE_1_LEFT_EXTR (X1_MIN_POS + 55)
-#define Y_SIGMA_PROBE_1_LEFT_EXTR (Y_MIN_POS + 265)
-//#define Y_SIGMA_PROBE_1_LEFT_EXTR 275
 
-#define X_SIGMA_PROBE_2_LEFT_EXTR (X1_MIN_POS + 55)
-#define Y_SIGMA_PROBE_2_LEFT_EXTR (Y_MIN_POS + 10)
-//#define Y_SIGMA_PROBE_2_LEFT_EXTR 10
-
-#define X_SIGMA_PROBE_3_LEFT_EXTR (X1_MIN_POS + 254)
-#define Y_SIGMA_PROBE_3_LEFT_EXTR (Y_MIN_POS + 10)
-//#define Y_SIGMA_PROBE_3_LEFT_EXTR 10
-
-//Right extruder probe point
-#define X_SIGMA_PROBE_1_RIGHT_EXTR (X1_MIN_POS + 254)
-#define Y_SIGMA_PROBE_1_RIGHT_EXTR (Y_MIN_POS + 265)
-//#define Y_SIGMA_PROBE_1_RIGHT_EXTR 275
-
-#define X_SIGMA_PROBE_2_RIGHT_EXTR (X1_MIN_POS + 254)
-#define Y_SIGMA_PROBE_2_RIGHT_EXTR (Y_MIN_POS + 10)
-//#define Y_SIGMA_PROBE_2_RIGHT_EXTR 10
-
-#define X_SIGMA_PROBE_3_RIGHT_EXTR (X1_MIN_POS + 55) 
-#define Y_SIGMA_PROBE_3_RIGHT_EXTR (Y_MIN_POS + 10)
-//#define Y_SIGMA_PROBE_3_RIGHT_EXTR 10
-
-#define X_GAP_AVOID_COLLISION_LEFT	10
-#define X_GAP_AVOID_COLLISION_RIGHT	13
-
-//Screw positions on BED for
-#define CARGOL_1_X  152
-//#define CARGOL_1_X  104;
-#define CARGOL_1_Y  272.5
-
-#define CARGOL_2_X  74.5
-//#define CARGOL_2_X  17;
-#define CARGOL_2_Y  19
-
-#define CARGOL_3_X  230.5
-//#define CARGOL_3_X  192;
-#define CARGOL_3_Y 19
-
-#define DEFAULT_DUPLICATION_X_OFFSET 105
-
-#define PARKING_COLLISON_AVOIDANCE
-#ifdef PARKING_COLLISON_AVOIDANCE
-	#define PARKING_COLLISON_AVOIDANCE_Y_UPPER 50.0
-	#define PARKING_COLLISON_AVOIDANCE_Y_LOWER 20.0
-#endif
-
-#endif
-
-#if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_EPSILON
 
 #define X_SIGMA_PROBE_SHIFT_BETWEEN 20
 
@@ -131,20 +78,29 @@
 #define X_SIGMA_PROBE_3_RIGHT_EXTR	 X_SIGMA_PROBE_2_LEFT_EXTR
 #define Y_SIGMA_PROBE_3_RIGHT_EXTR	 Y_SIGMA_PROBE_2_LEFT_EXTR
 
+__attribute__((unused)) static float x_probe_left_extr[3] = {X_SIGMA_PROBE_1_LEFT_EXTR, X_SIGMA_PROBE_2_LEFT_EXTR, X_SIGMA_PROBE_3_LEFT_EXTR};
+__attribute__((unused)) static float y_probe_left_extr[3] = {Y_SIGMA_PROBE_1_LEFT_EXTR, Y_SIGMA_PROBE_2_LEFT_EXTR, Y_SIGMA_PROBE_3_LEFT_EXTR};
+__attribute__((unused)) static float x_probe_right_extr[3] = {X_SIGMA_PROBE_1_RIGHT_EXTR, X_SIGMA_PROBE_2_RIGHT_EXTR, X_SIGMA_PROBE_3_RIGHT_EXTR};
+__attribute__((unused)) static float y_probe_right_extr[3] = {Y_SIGMA_PROBE_1_RIGHT_EXTR, Y_SIGMA_PROBE_2_RIGHT_EXTR, Y_SIGMA_PROBE_3_RIGHT_EXTR};
+
 #define X_GAP_AVOID_COLLISION_LEFT	(13.2)
 #define X_GAP_AVOID_COLLISION_RIGHT	(12.7)
 
-#define CARGOL_1_X  (X1_MIN_POS + 262.9)
-//#define CARGOL_1_X  104;
-#define CARGOL_1_Y  (Y_MAX_POS + 30.3)
+__attribute__((unused)) static float x_screw_bed_calib_1 = (X1_MIN_POS + 262.9);
+__attribute__((unused)) static float y_screw_bed_calib_1 = (Y_MAX_POS + 30.3);
+__attribute__((unused)) static float x_screw_bed_calib_2 = (X1_MIN_POS + 54.4);
+__attribute__((unused)) static float y_screw_bed_calib_2 = (Y_MAX_POS - 297.2);
+__attribute__((unused)) static float x_screw_bed_calib_3 = (X1_MIN_POS + 471.4);
+__attribute__((unused)) static float y_screw_bed_calib_3 = (Y_MAX_POS - 297.2);
 
-#define CARGOL_2_X  (X1_MIN_POS + 54.4)
-//#define CARGOL_2_X  17;
-#define CARGOL_2_Y  (Y_MAX_POS - 297.2)
+#define CARGOL_1_X  x_screw_bed_calib_1
+#define CARGOL_1_Y  y_screw_bed_calib_1
 
-#define CARGOL_3_X  (X1_MIN_POS + 471.4)
-//#define CARGOL_3_X  192;
-#define CARGOL_3_Y  CARGOL_2_Y
+#define CARGOL_2_X  x_screw_bed_calib_2
+#define CARGOL_2_Y  y_screw_bed_calib_2
+
+#define CARGOL_3_X  x_screw_bed_calib_3
+#define CARGOL_3_Y  y_screw_bed_calib_3
 
 #define DEFAULT_DUPLICATION_X_OFFSET 210
 
@@ -154,7 +110,6 @@
 	#define PARKING_COLLISON_AVOIDANCE_Y_LOWER 20.0
 #endif
 
-#endif
 
 #define Z_RAISE_BEF_PROBING 5      //How much the extruder will be raised before traveling to the first probing point.
 #define Z_RAISE_BET_PROBINGS 2.5  //How much the extruder will be raised when traveling from between next probing points

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -8,7 +8,7 @@
 
 #define BCN3D_MOD
 
-#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
+//#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
 #ifdef BCN3D_PRINT_SIMULATION
 	#define SIMULATION_TEMP_AMB							22.5
 #endif
@@ -18,21 +18,11 @@
 #define RAFT_Z_THRESHOLD 0.05
 //	END DUAL MODE SETTINGS
 
-//////	PAUSE PRINT
-#if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_EPSILON
-#define RETRACT_PRINTER_FACTOR			 8				//(mm)
-#define RETRACT_PRINT_TEST_FACTOR		 8				//(mm)
-#define PAUSE_G69_XYMOVE				 5				//(mm)
-#define PAUSE_G70_ZMOVE					 2				//(mm)
-#define PURGE_PRINTER_FACTOR			 20				//(mm)
-#endif
-#if BCN3D_PRINTER_SETUP == BCN3D_PRINTER_IS_SIGMA
-#define RETRACT_PRINTER_FACTOR			 6				//(mm)
-#define RETRACT_PRINT_TEST_FACTOR		 6				//(mm)
-#define PAUSE_G69_XYMOVE				 5				//(mm)
-#define PAUSE_G70_ZMOVE					 2				//(mm)
-#define PURGE_PRINTER_FACTOR			 20				//(mm)
-#endif
+
+#define RETRACT_PRINTER_FACTOR			 retract_printer_factor				//(mm)
+#define RETRACT_PRINT_TEST_FACTOR		 retract_print_test_factor			//(mm)
+#define PURGE_PRINTER_FACTOR			 purge_printer_factor				//(mm)
+
 
 //RETRACT SETTINGS
 

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -8,7 +8,7 @@
 
 #define BCN3D_MOD
 
-//#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
+#define BCN3D_PRINT_SIMULATION							//Dummy driver emulator, this define must be disabled
 #ifdef BCN3D_PRINT_SIMULATION
 	#define SIMULATION_TEMP_AMB							22.5
 #endif

--- a/Marlin/bcn3dcfg_adv.h
+++ b/Marlin/bcn3dcfg_adv.h
@@ -93,3 +93,5 @@
 #define Z_RAISE_BET_PROBINGS 2.5  //How much the extruder will be raised when traveling from between next probing points
 
 #define FANSPEED_CLASSIC // Support classic fan speed usage
+
+#define G36_LAYER_DIF 0.1

--- a/Marlin/chamberFanPWM.cpp
+++ b/Marlin/chamberFanPWM.cpp
@@ -3,44 +3,13 @@
 
 #define PWM_MAX_PERIOD 5
 
-//Counters
-uint8_t dutycycle = 0; //value range 0% to 100;
-uint8_t counter_timer = 0; //value range 0% to 100;
-
 //Class call
 ChamberFanPWM chamberFanPWM;
 
-//Timer
-uint32_t timeelapsed_fan = 0;
-
 //#define ENABLE_PWM_CHAMBER
 
-void ChamberFanPWM::setup(){
-
-	// Set led pins as output and low
-	pinMode(CHAMBER_AUTO_FAN_PIN,OUTPUT);
-	
-	digitalWrite(CHAMBER_AUTO_FAN_PIN,LOW);
-	
-	//Setup Timer4 to fire every 1ms
-	TCCR4A = 0;// set entire TCCR1A register to 0
-	TCCR4B = 0;// same for TCCR1B
-	TCNT4  = 0;//initialize counter value to 0
-	// set compare match register for 1hz increments
-	OCR4A = 500;// = (16*10^6) / (1*1024) - 1 (must be <65536)
-	// turn on CTC mode
-	TCCR4B |= (1 << WGM12);
-	// Set CS12 and CS10 bits for 64 prescaler
-	TCCR4B |= (1 << CS11) | (1 << CS10);
-	// enable timer compare interrupt
-	TIMSK4 |= (1 << OCIE4A);
-	
-	dutycycle = DEFAULT_DUTYCYCLE_CHAMBER; // 20 %
-	timeelapsed_fan = millis();
-}
-
-void ChamberFanPWM::setup(uint16_t timer_period){
-
+void ChamberFanPWM::setup(uint16_t timer_period)
+{
 	// Set led pins as output and low
 	pinMode(CHAMBER_AUTO_FAN_PIN,OUTPUT);
 	
@@ -63,9 +32,8 @@ void ChamberFanPWM::setup(uint16_t timer_period){
 	timeelapsed_fan = millis();
 }
 
-
-ISR(TIMER4_COMPA_vect) {
 #ifdef ENABLE_PWM_CHAMBER
+ISR(TIMER4_COMPA_vect) {
 	if(millis() > timeelapsed_fan + 500)
 	{
 		if(counter_timer < dutycycle){
@@ -78,10 +46,9 @@ ISR(TIMER4_COMPA_vect) {
 		}else{
 		digitalWrite(CHAMBER_AUTO_FAN_PIN,HIGH);
 	}
-#else
-	digitalWrite(CHAMBER_AUTO_FAN_PIN,HIGH);
-#endif
 }
+#endif
+
 void ChamberFanPWM::setDuty(uint8_t duty) {
 	
 	if(dutycycle != duty){

--- a/Marlin/chamberFanPWM.h
+++ b/Marlin/chamberFanPWM.h
@@ -11,14 +11,18 @@
 
 class ChamberFanPWM {
 	
-	public:
+public:
 	ChamberFanPWM() {}
 
-	static void setup();
-	static void setup(uint16_t timer_period);
-	
-	static void setDuty(uint8_t duty);
+	void setup(uint16_t timer_period = 500);
+	void setDuty(uint8_t duty);
 
+private:
+	//Counters
+	uint8_t dutycycle = 0; //value range 0% to 100;
+	uint8_t counter_timer = 0; //value range 0% to 100;
+	//Timer
+	uint32_t timeelapsed_fan = 0;
 };
 
 extern ChamberFanPWM chamberFanPWM;

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1805,7 +1805,7 @@ void MarlinSettings::reset() {
   #endif
 
   #if HOTENDS > 1
-    constexpr float tmp4[XYZ][HOTENDS] = {
+      float tmp4[XYZ][HOTENDS] = {
       HOTEND_OFFSET_X,
       HOTEND_OFFSET_Y
       #if HAS_HOTEND_OFFSET_Z
@@ -1814,10 +1814,10 @@ void MarlinSettings::reset() {
         , { 0 }
       #endif
     };
-    static_assert(
-      tmp4[X_AXIS][0] == 0 && tmp4[Y_AXIS][0] == 0 && tmp4[Z_AXIS][0] == 0,
-      "Offsets for the first hotend must be 0.0."
-    );
+    //static_assert(
+      //tmp4[X_AXIS][0] == 0 && tmp4[Y_AXIS][0] == 0 && tmp4[Z_AXIS][0] == 0,
+      //"Offsets for the first hotend must be 0.0."
+    //);
     LOOP_XYZ(i) HOTEND_LOOP() hotend_offset[i][e] = tmp4[i][e];
   #endif
 

--- a/Marlin/emergency_parser.cpp
+++ b/Marlin/emergency_parser.cpp
@@ -31,6 +31,7 @@
 #include "emergency_parser.h"
 
 // Static data members
+bool EmergencyParser::has_line_number; // = false
 bool EmergencyParser::killed_by_M112; // = false
 EmergencyParser::State EmergencyParser::state; // = EP_RESET
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -64,6 +64,7 @@
   #endif
 #endif
 
+
 Temperature thermalManager;
 
 /**
@@ -168,193 +169,251 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 		{
 			case 1:
 				heater_ttbl_map[index]=temptable_1;
+				heater_ttbllen_map[index]=COUNT(temptable_1);
 			break;
 			case 10:
 				heater_ttbl_map[index]=temptable_10;
+				heater_ttbllen_map[index]=COUNT(temptable_10);
 			break;
 			case 1010:
 				heater_ttbl_map[index]=temptable_1010;
+				heater_ttbllen_map[index]=COUNT(temptable_1010);
 			break;
 			case 1047:
 				heater_ttbl_map[index]=temptable_1047;
+				heater_ttbllen_map[index]=COUNT(temptable_1047);
 			break;
 			case 11:
 			heater_ttbl_map[index]=temptable_11;
+			heater_ttbllen_map[index]=COUNT(temptable_11);
 			break;
 			case 110:
 			heater_ttbl_map[index]=temptable_110;
+			heater_ttbllen_map[index]=COUNT(temptable_110);
 			break;
 			case 12:
 			heater_ttbl_map[index]=temptable_12;
+			heater_ttbllen_map[index]=COUNT(temptable_12);
 			break;
 			case 13:
 			heater_ttbl_map[index]=temptable_13;
+			heater_ttbllen_map[index]=COUNT(temptable_13);
 			break;
 			case 147:
 			heater_ttbl_map[index]=temptable_147;
+			heater_ttbllen_map[index]=COUNT(temptable_147);
 			break;
 			case 15:
 			heater_ttbl_map[index]=temptable_15;
+			heater_ttbllen_map[index]=COUNT(temptable_15);
 			break;
 			case 2:
 			heater_ttbl_map[index]=temptable_2;
+			heater_ttbllen_map[index]=COUNT(temptable_2);
 			break;
 			case 20:
 			heater_ttbl_map[index]=temptable_20;
+			heater_ttbllen_map[index]=COUNT(temptable_20);
 			break;
 			case 3:
 			heater_ttbl_map[index]=temptable_3;
+			heater_ttbllen_map[index]=COUNT(temptable_3);
 			break;
 			case 4:
 			heater_ttbl_map[index]=temptable_4;
+			heater_ttbllen_map[index]=COUNT(temptable_4);
 			break;
 			case 5:
 			heater_ttbl_map[index]=temptable_5;
+			heater_ttbllen_map[index]=COUNT(temptable_5);
 			break;
 			case 501:
 			heater_ttbl_map[index]=temptable_501;
+			heater_ttbllen_map[index]=COUNT(temptable_501);
 			break;
 			case 51:
 			heater_ttbl_map[index]=temptable_51;
+			heater_ttbllen_map[index]=COUNT(temptable_51);
 			break;
 			case 52:
 			heater_ttbl_map[index]=temptable_52;
+			heater_ttbllen_map[index]=COUNT(temptable_52);
 			break;
 			case 55:
 			heater_ttbl_map[index]=temptable_55;
+			heater_ttbllen_map[index]=COUNT(temptable_55);
 			break;
 			case 6:
 			heater_ttbl_map[index]=temptable_6;
+			heater_ttbllen_map[index]=COUNT(temptable_6);
 			break;
 			case 60:
 			heater_ttbl_map[index]=temptable_60;
+			heater_ttbllen_map[index]=COUNT(temptable_60);
 			break;
 			case 66:
 			heater_ttbl_map[index]=temptable_66;
+			heater_ttbllen_map[index]=COUNT(temptable_66);
 			break;
 			case 7:
 			heater_ttbl_map[index]=temptable_7;
+			heater_ttbllen_map[index]=COUNT(temptable_7);
 			break;
 			case 70:
 			heater_ttbl_map[index]=temptable_70;
+			heater_ttbllen_map[index]=COUNT(temptable_70);
 			break;
 			case 71:
 			heater_ttbl_map[index]=temptable_71;
+			heater_ttbllen_map[index]=COUNT(temptable_71);
 			break;
 			case 75:
 			heater_ttbl_map[index]=temptable_75;
+			heater_ttbllen_map[index]=COUNT(temptable_75);
 			break;
 			case 8:
 			heater_ttbl_map[index]=temptable_8;
+			heater_ttbllen_map[index]=COUNT(temptable_8);
 			break;
 			case 9:
 			heater_ttbl_map[index]=temptable_9;
+			heater_ttbllen_map[index]=COUNT(temptable_9);
 			break;
 			case 998:
 			heater_ttbl_map[index]=temptable_998;
+			heater_ttbllen_map[index]=COUNT(temptable_998);
 			break;
 			case 999:
 			heater_ttbl_map[index]=temptable_999;
+			heater_ttbllen_map[index]=COUNT(temptable_999);
 			break;		
 		}
-		heater_ttbllen_map[index]=COUNT(&heater_ttbl_map[index]);
+		
 	}
 	void Temperature::update_bed_ttbl(uint16_t sensorId){
 		switch(sensorId)
 		{
 			case 1:
-			bedTempTable=temptable_1;
-			
+			bedTempTable[0]=temptable_1;
+			bedTempTableLen[0]=COUNT(temptable_1);
 			break;
 			case 10:
-			bedTempTable=temptable_10;
+			bedTempTable[0]=temptable_10;
+			bedTempTableLen[0]=COUNT(temptable_10);
 			break;
 			case 1010:
-			bedTempTable=temptable_1010;
+			bedTempTable[0]=temptable_1010;
+			bedTempTableLen[0]=COUNT(temptable_1010);
 			break;
 			case 1047:
-			bedTempTable=temptable_1047;
+			bedTempTable[0]=temptable_1047;
+			bedTempTableLen[0]=COUNT(temptable_1047);
 			break;
 			case 11:
-			bedTempTable=temptable_11;
+			bedTempTable[0]=temptable_11;
+			bedTempTableLen[0]=COUNT(temptable_11);
 			break;
 			case 110:
-			bedTempTable=temptable_110;
+			bedTempTable[0]=temptable_110;
+			bedTempTableLen[0]=COUNT(temptable_110);
 			break;
 			case 12:
-			bedTempTable=temptable_12;
+			bedTempTable[0]=temptable_12;
+			bedTempTableLen[0]=COUNT(temptable_12);
 			break;
 			case 13:
-			bedTempTable=temptable_13;
+			bedTempTable[0]=temptable_13;
+			bedTempTableLen[0]=COUNT(temptable_13);
 			break;
 			case 147:
-			bedTempTable=temptable_147;
+			bedTempTable[0]=temptable_147;
+			bedTempTableLen[0]=COUNT(temptable_147);
 			break;
 			case 15:
-			bedTempTable=temptable_15;
+			bedTempTable[0]=temptable_15;
+			bedTempTableLen[0]=COUNT(temptable_15);
 			break;
 			case 2:
-			bedTempTable=temptable_2;
+			bedTempTable[0]=temptable_2;
+			bedTempTableLen[0]=COUNT(temptable_2);
 			break;
 			case 20:
-			bedTempTable=temptable_20;
+			bedTempTable[0]=temptable_20;
+			bedTempTableLen[0]=COUNT(temptable_20);
 			break;
 			case 3:
-			bedTempTable=temptable_3;
+			bedTempTable[0]=temptable_3;
+			bedTempTableLen[0]=COUNT(temptable_3);
 			break;
 			case 4:
-			bedTempTable=temptable_4;
+			bedTempTable[0]=temptable_4;
+			bedTempTableLen[0]=COUNT(temptable_4);
 			break;
 			case 5:
-			bedTempTable=temptable_5;
+			bedTempTable[0]=temptable_5;
+			bedTempTableLen[0]=COUNT(temptable_5);
 			break;
 			case 501:
-			bedTempTable=temptable_501;
+			bedTempTable[0]=temptable_501;
+			bedTempTableLen[0]=COUNT(temptable_501);
 			break;
 			case 51:
-			bedTempTable=temptable_51;
+			bedTempTable[0]=temptable_51;
+			bedTempTableLen[0]=COUNT(temptable_51);
 			break;
 			case 52:
-			bedTempTable=temptable_52;
+			bedTempTable[0]=temptable_52;
+			bedTempTableLen[0]=COUNT(temptable_52);
 			break;
 			case 55:
-			bedTempTable=temptable_55;
+			bedTempTable[0]=temptable_55;
+			bedTempTableLen[0]=COUNT(temptable_55);
 			break;
 			case 6:
-			bedTempTable=temptable_6;
+			bedTempTable[0]=temptable_6;
+			bedTempTableLen[0]=COUNT(temptable_6);
 			break;
 			case 60:
-			bedTempTable=temptable_60;
+			bedTempTable[0]=temptable_60;
+			bedTempTableLen[0]=COUNT(temptable_60);
 			break;
 			case 66:
-			bedTempTable=temptable_66;
+			bedTempTable[0]=temptable_66;
+			bedTempTableLen[0]=COUNT(temptable_66);
 			break;
 			case 7:
-			bedTempTable=temptable_7;
+			bedTempTable[0]=temptable_7;
+			bedTempTableLen[0]=COUNT(temptable_7);
 			break;
 			case 70:
-			bedTempTable=temptable_70;
+			bedTempTable[0]=temptable_70;
+			bedTempTableLen[0]=COUNT(temptable_70);
 			break;
 			case 71:
-			bedTempTable=temptable_71;
+			bedTempTable[0]=temptable_71;
+			bedTempTableLen[0]=COUNT(temptable_71);
 			break;
 			case 75:
-			bedTempTable=temptable_75;
+			bedTempTable[0]=temptable_75;
+			bedTempTableLen[0]=COUNT(temptable_75);
 			break;
 			case 8:
-			bedTempTable=temptable_8;
+			bedTempTable[0]=temptable_8;
+			bedTempTableLen[0]=COUNT(temptable_8);
 			break;
 			case 9:
-			bedTempTable=temptable_9;
+			bedTempTable[0]=temptable_9;
+			bedTempTableLen[0]=COUNT(temptable_9);
 			break;
 			case 998:
-			bedTempTable=temptable_998;
+			bedTempTable[0]=temptable_998;
+			bedTempTableLen[0]=COUNT(temptable_998);
 			break;
 			case 999:
-			bedTempTable=temptable_999;
+			bedTempTable[0]=temptable_999;
+			bedTempTableLen[0]=COUNT(temptable_999);
 			break;
 		}
-		bedTempTableLen = COUNT(&bedTempTable);
 	}
 	
 #endif
@@ -1199,9 +1258,9 @@ float Temperature::analog2temp(const int raw, const uint8_t e) {
   // For bed temperature measurement.
   float Temperature::analog2tempBed(const int raw) {
     #if ENABLED(HEATER_BED_USES_THERMISTOR)
-	//const short(*tt)[][2] = (short(*)[][2])(bedTempTable);
-      //SCAN_THERMISTOR_TABLE((*tt), bedTempTableLen);
-	 SCAN_THERMISTOR_TABLE((BEDTEMPTABLE), BEDTEMPTABLE_LEN);
+	const short(*tt)[][2] = (short(*)[][2])(bedTempTable[0]);
+      SCAN_THERMISTOR_TABLE((*tt), bedTempTableLen[0]);
+	 //SCAN_THERMISTOR_TABLE((BEDTEMPTABLE), BEDTEMPTABLE_LEN);
     #elif ENABLED(HEATER_BED_USES_AD595)
       return TEMP_AD595(raw);
     #elif ENABLED(HEATER_BED_USES_AD8495)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -477,6 +477,163 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 
 	}
 	
+	void Temperature::update_chamber_ttbl(uint16_t sensorId){
+		switch(sensorId)
+		{
+			case 1:
+			chamberTempTable[0]=temptable_1;
+			chamberTempTableLen[0]=COUNT(temptable_1);
+			sensor_name_chamber=THERMISTOR_NAME_1;
+			break;
+			case 10:
+			chamberTempTable[0]=temptable_10;
+			chamberTempTableLen[0]=COUNT(temptable_10);
+			sensor_name_chamber=THERMISTOR_NAME_10;
+			break;
+			case 1010:
+			chamberTempTable[0]=temptable_1010;
+			chamberTempTableLen[0]=COUNT(temptable_1010);
+			sensor_name_chamber=THERMISTOR_NAME_1010;
+			break;
+			case 1047:
+			chamberTempTable[0]=temptable_1047;
+			chamberTempTableLen[0]=COUNT(temptable_1047);
+			sensor_name_chamber=THERMISTOR_NAME_1047;
+			break;
+			case 11:
+			chamberTempTable[0]=temptable_11;
+			chamberTempTableLen[0]=COUNT(temptable_11);
+			sensor_name_chamber=THERMISTOR_NAME_11;
+			break;
+			case 110:
+			chamberTempTable[0]=temptable_110;
+			chamberTempTableLen[0]=COUNT(temptable_110);
+			sensor_name_chamber=THERMISTOR_NAME_110;
+			break;
+			case 12:
+			chamberTempTable[0]=temptable_12;
+			chamberTempTableLen[0]=COUNT(temptable_12);
+			sensor_name_chamber=THERMISTOR_NAME_12;
+			break;
+			case 13:
+			chamberTempTable[0]=temptable_13;
+			chamberTempTableLen[0]=COUNT(temptable_13);
+			sensor_name_chamber=THERMISTOR_NAME_13;
+			break;
+			case 147:
+			chamberTempTable[0]=temptable_147;
+			chamberTempTableLen[0]=COUNT(temptable_147);
+			sensor_name_chamber=THERMISTOR_NAME_147;
+			break;
+			case 15:
+			chamberTempTable[0]=temptable_15;
+			chamberTempTableLen[0]=COUNT(temptable_15);
+			sensor_name_chamber=THERMISTOR_NAME_15;
+			break;
+			case 2:
+			chamberTempTable[0]=temptable_2;
+			chamberTempTableLen[0]=COUNT(temptable_2);
+			sensor_name_chamber=THERMISTOR_NAME_2;
+			break;
+			case 20:
+			chamberTempTable[0]=temptable_20;
+			chamberTempTableLen[0]=COUNT(temptable_20);
+			sensor_name_chamber=THERMISTOR_NAME_20;
+			break;
+			case 3:
+			chamberTempTable[0]=temptable_3;
+			chamberTempTableLen[0]=COUNT(temptable_3);
+			sensor_name_chamber=THERMISTOR_NAME_3;
+			break;
+			case 4:
+			chamberTempTable[0]=temptable_4;
+			chamberTempTableLen[0]=COUNT(temptable_4);
+			sensor_name_chamber=THERMISTOR_NAME_4;
+			break;
+			case 5:
+			chamberTempTable[0]=temptable_5;
+			chamberTempTableLen[0]=COUNT(temptable_5);
+			sensor_name_chamber=THERMISTOR_NAME_5;
+			break;
+			case 501:
+			chamberTempTable[0]=temptable_501;
+			chamberTempTableLen[0]=COUNT(temptable_501);
+			sensor_name_chamber=THERMISTOR_NAME_501;
+			break;
+			case 51:
+			chamberTempTable[0]=temptable_51;
+			chamberTempTableLen[0]=COUNT(temptable_51);
+			sensor_name_chamber=THERMISTOR_NAME_51;
+			break;
+			case 52:
+			chamberTempTable[0]=temptable_52;
+			chamberTempTableLen[0]=COUNT(temptable_52);
+			sensor_name_chamber=THERMISTOR_NAME_52;
+			break;
+			case 55:
+			chamberTempTable[0]=temptable_55;
+			chamberTempTableLen[0]=COUNT(temptable_55);
+			sensor_name_chamber=THERMISTOR_NAME_55;
+			break;
+			case 6:
+			chamberTempTable[0]=temptable_6;
+			chamberTempTableLen[0]=COUNT(temptable_6);
+			sensor_name_chamber=THERMISTOR_NAME_6;
+			break;
+			case 60:
+			chamberTempTable[0]=temptable_60;
+			chamberTempTableLen[0]=COUNT(temptable_60);
+			sensor_name_chamber=THERMISTOR_NAME_60;
+			break;
+			case 66:
+			chamberTempTable[0]=temptable_66;
+			chamberTempTableLen[0]=COUNT(temptable_66);
+			sensor_name_chamber=THERMISTOR_NAME_66;
+			break;
+			case 7:
+			chamberTempTable[0]=temptable_7;
+			chamberTempTableLen[0]=COUNT(temptable_7);
+			sensor_name_chamber=THERMISTOR_NAME_7;
+			break;
+			case 70:
+			chamberTempTable[0]=temptable_70;
+			chamberTempTableLen[0]=COUNT(temptable_70);
+			sensor_name_chamber=THERMISTOR_NAME_70;
+			break;
+			case 71:
+			chamberTempTable[0]=temptable_71;
+			chamberTempTableLen[0]=COUNT(temptable_71);
+			sensor_name_chamber=THERMISTOR_NAME_71;
+			break;
+			case 75:
+			chamberTempTable[0]=temptable_75;
+			chamberTempTableLen[0]=COUNT(temptable_75);
+			sensor_name_chamber=THERMISTOR_NAME_75;
+			break;
+			case 8:
+			chamberTempTable[0]=temptable_8;
+			chamberTempTableLen[0]=COUNT(temptable_8);
+			sensor_name_chamber=THERMISTOR_NAME_8;
+			break;
+			case 9:
+			chamberTempTable[0]=temptable_9;
+			chamberTempTableLen[0]=COUNT(temptable_9);
+			sensor_name_chamber=THERMISTOR_NAME_9;
+			break;
+			case 998:
+			chamberTempTable[0]=temptable_998;
+			chamberTempTableLen[0]=COUNT(temptable_998);
+			sensor_name_chamber=THERMISTOR_NAME_998;
+			break;
+			case 999:
+			bedTempTable[0]=temptable_999;
+			bedTempTableLen[0]=COUNT(temptable_999);
+			sensor_name_bed=THERMISTOR_NAME_999;
+			break;
+		}
+
+	}
+	
 	void Temperature::report_sensors_names(){
 				SERIAL_ECHO_START();
 				#if THERMISTORHEATER_0
@@ -496,6 +653,9 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 				#endif
 				#ifdef THERMISTORBED 
 				SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
+				#endif
+				#ifdef THERMISTORCHAMBER
+				SERIAL_ECHOLNPAIR("Chamber sensor: ", sensor_name_chamber);
 				#endif
 	}
 #endif

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -163,7 +163,7 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 #endif
 
 #ifdef BCN3D_MOD
-	void Temperature::update_heater_ttbl_map(uint8_t index, uint16_t sensorId){
+	void Temperature::update_heater_ttbl_map(int8_t index, uint16_t sensorId){
 		switch(sensorId)
 		{
 			case 1:
@@ -1199,8 +1199,9 @@ float Temperature::analog2temp(const int raw, const uint8_t e) {
   // For bed temperature measurement.
   float Temperature::analog2tempBed(const int raw) {
     #if ENABLED(HEATER_BED_USES_THERMISTOR)
-	const short(*tt)[][2] = (short(*)[][2])(bedTempTable);
-      SCAN_THERMISTOR_TABLE((*tt), bedTempTableLen);
+	//const short(*tt)[][2] = (short(*)[][2])(bedTempTable);
+      //SCAN_THERMISTOR_TABLE((*tt), bedTempTableLen);
+	 SCAN_THERMISTOR_TABLE((BEDTEMPTABLE), BEDTEMPTABLE_LEN);
     #elif ENABLED(HEATER_BED_USES_AD595)
       return TEMP_AD595(raw);
     #elif ENABLED(HEATER_BED_USES_AD8495)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -61,6 +61,7 @@
   #else
     static void* heater_ttbl_map[HOTENDS] = ARRAY_BY_HOTENDS((void*)HEATER_0_TEMPTABLE, (void*)HEATER_1_TEMPTABLE, (void*)HEATER_2_TEMPTABLE, (void*)HEATER_3_TEMPTABLE, (void*)HEATER_4_TEMPTABLE);
     static uint8_t heater_ttbllen_map[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN, HEATER_2_TEMPTABLE_LEN, HEATER_3_TEMPTABLE_LEN, HEATER_4_TEMPTABLE_LEN);
+	static char* heater_sensor_names[HOTENDS] = ARRAY_BY_HOTENDS(sensor_name_heater0, sensor_name_heater1, sensor_name_heater2, sensor_name_heater3, sensor_name_heater4);
   #endif
 #endif
 
@@ -170,125 +171,154 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 			case 1:
 				heater_ttbl_map[index]=temptable_1;
 				heater_ttbllen_map[index]=COUNT(temptable_1);
+				heater_sensor_names[index]=THERMISTOR_NAME_1;
 			break;
 			case 10:
 				heater_ttbl_map[index]=temptable_10;
 				heater_ttbllen_map[index]=COUNT(temptable_10);
+				heater_sensor_names[index]=THERMISTOR_NAME_10;
 			break;
 			case 1010:
 				heater_ttbl_map[index]=temptable_1010;
 				heater_ttbllen_map[index]=COUNT(temptable_1010);
+				heater_sensor_names[index]=THERMISTOR_NAME_1010;
 			break;
 			case 1047:
 				heater_ttbl_map[index]=temptable_1047;
 				heater_ttbllen_map[index]=COUNT(temptable_1047);
+				heater_sensor_names[index]=THERMISTOR_NAME_1047;
 			break;
 			case 11:
-			heater_ttbl_map[index]=temptable_11;
-			heater_ttbllen_map[index]=COUNT(temptable_11);
+				heater_ttbl_map[index]=temptable_11;
+				heater_ttbllen_map[index]=COUNT(temptable_11);
+				heater_sensor_names[index]=THERMISTOR_NAME_11;
 			break;
 			case 110:
-			heater_ttbl_map[index]=temptable_110;
-			heater_ttbllen_map[index]=COUNT(temptable_110);
+				heater_ttbl_map[index]=temptable_110;
+				heater_ttbllen_map[index]=COUNT(temptable_110);
+				heater_sensor_names[index]=THERMISTOR_NAME_110;
 			break;
 			case 12:
-			heater_ttbl_map[index]=temptable_12;
-			heater_ttbllen_map[index]=COUNT(temptable_12);
+				heater_ttbl_map[index]=temptable_12;
+				heater_ttbllen_map[index]=COUNT(temptable_12);
+				heater_sensor_names[index]=THERMISTOR_NAME_12;
 			break;
 			case 13:
-			heater_ttbl_map[index]=temptable_13;
-			heater_ttbllen_map[index]=COUNT(temptable_13);
+				heater_ttbl_map[index]=temptable_13;
+				heater_ttbllen_map[index]=COUNT(temptable_13);
+				heater_sensor_names[index]=THERMISTOR_NAME_13;
 			break;
 			case 147:
-			heater_ttbl_map[index]=temptable_147;
-			heater_ttbllen_map[index]=COUNT(temptable_147);
+				heater_ttbl_map[index]=temptable_147;
+				heater_ttbllen_map[index]=COUNT(temptable_147);
+				heater_sensor_names[index]=THERMISTOR_NAME_147;
 			break;
 			case 15:
-			heater_ttbl_map[index]=temptable_15;
-			heater_ttbllen_map[index]=COUNT(temptable_15);
+				heater_ttbl_map[index]=temptable_15;
+				heater_ttbllen_map[index]=COUNT(temptable_15);
+				heater_sensor_names[index]=THERMISTOR_NAME_15;
 			break;
 			case 2:
-			heater_ttbl_map[index]=temptable_2;
-			heater_ttbllen_map[index]=COUNT(temptable_2);
+				heater_ttbl_map[index]=temptable_2;
+				heater_ttbllen_map[index]=COUNT(temptable_2);
+				heater_sensor_names[index]=THERMISTOR_NAME_2;
 			break;
 			case 20:
-			heater_ttbl_map[index]=temptable_20;
-			heater_ttbllen_map[index]=COUNT(temptable_20);
+				heater_ttbl_map[index]=temptable_20;
+				heater_ttbllen_map[index]=COUNT(temptable_20);
+				heater_sensor_names[index]=THERMISTOR_NAME_20;
 			break;
 			case 3:
-			heater_ttbl_map[index]=temptable_3;
-			heater_ttbllen_map[index]=COUNT(temptable_3);
+				heater_ttbl_map[index]=temptable_3;
+				heater_ttbllen_map[index]=COUNT(temptable_3);
+				heater_sensor_names[index]=THERMISTOR_NAME_3;
 			break;
 			case 4:
-			heater_ttbl_map[index]=temptable_4;
-			heater_ttbllen_map[index]=COUNT(temptable_4);
+				heater_ttbl_map[index]=temptable_4;
+				heater_ttbllen_map[index]=COUNT(temptable_4);
+				heater_sensor_names[index]=THERMISTOR_NAME_4;
 			break;
 			case 5:
-			heater_ttbl_map[index]=temptable_5;
-			heater_ttbllen_map[index]=COUNT(temptable_5);
+				heater_ttbl_map[index]=temptable_5;
+				heater_ttbllen_map[index]=COUNT(temptable_5);
+				heater_sensor_names[index]=THERMISTOR_NAME_4;
 			break;
 			case 501:
-			heater_ttbl_map[index]=temptable_501;
-			heater_ttbllen_map[index]=COUNT(temptable_501);
+				heater_ttbl_map[index]=temptable_501;
+				heater_ttbllen_map[index]=COUNT(temptable_501);
+				heater_sensor_names[index]=THERMISTOR_NAME_501;
 			break;
 			case 51:
-			heater_ttbl_map[index]=temptable_51;
-			heater_ttbllen_map[index]=COUNT(temptable_51);
+				heater_ttbl_map[index]=temptable_51;
+				heater_ttbllen_map[index]=COUNT(temptable_51);
+				heater_sensor_names[index]=THERMISTOR_NAME_51;
 			break;
 			case 52:
-			heater_ttbl_map[index]=temptable_52;
-			heater_ttbllen_map[index]=COUNT(temptable_52);
+				heater_ttbl_map[index]=temptable_52;
+				heater_ttbllen_map[index]=COUNT(temptable_52);
+				heater_sensor_names[index]=THERMISTOR_NAME_52;
 			break;
 			case 55:
-			heater_ttbl_map[index]=temptable_55;
-			heater_ttbllen_map[index]=COUNT(temptable_55);
+				heater_ttbl_map[index]=temptable_55;
+				heater_ttbllen_map[index]=COUNT(temptable_55);
+				heater_sensor_names[index]=THERMISTOR_NAME_55;
 			break;
 			case 6:
-			heater_ttbl_map[index]=temptable_6;
-			heater_ttbllen_map[index]=COUNT(temptable_6);
+				heater_ttbl_map[index]=temptable_6;
+				heater_ttbllen_map[index]=COUNT(temptable_6);
+				heater_sensor_names[index]=THERMISTOR_NAME_6;
 			break;
 			case 60:
-			heater_ttbl_map[index]=temptable_60;
-			heater_ttbllen_map[index]=COUNT(temptable_60);
+				heater_ttbl_map[index]=temptable_60;
+				heater_ttbllen_map[index]=COUNT(temptable_60);
+				heater_sensor_names[index]=THERMISTOR_NAME_60;
 			break;
 			case 66:
-			heater_ttbl_map[index]=temptable_66;
-			heater_ttbllen_map[index]=COUNT(temptable_66);
+				heater_ttbl_map[index]=temptable_66;
+				heater_ttbllen_map[index]=COUNT(temptable_66);
+				heater_sensor_names[index]=THERMISTOR_NAME_66;
 			break;
 			case 7:
-			heater_ttbl_map[index]=temptable_7;
-			heater_ttbllen_map[index]=COUNT(temptable_7);
+				heater_ttbl_map[index]=temptable_7;
+				heater_ttbllen_map[index]=COUNT(temptable_7);
+				heater_sensor_names[index]=THERMISTOR_NAME_7;
 			break;
 			case 70:
-			heater_ttbl_map[index]=temptable_70;
-			heater_ttbllen_map[index]=COUNT(temptable_70);
+				heater_ttbl_map[index]=temptable_70;
+				heater_ttbllen_map[index]=COUNT(temptable_70);
+				heater_sensor_names[index]=THERMISTOR_NAME_70;
 			break;
 			case 71:
-			heater_ttbl_map[index]=temptable_71;
-			heater_ttbllen_map[index]=COUNT(temptable_71);
+				heater_ttbl_map[index]=temptable_71;
+				heater_ttbllen_map[index]=COUNT(temptable_71);
+				heater_sensor_names[index]=THERMISTOR_NAME_71;
 			break;
 			case 75:
-			heater_ttbl_map[index]=temptable_75;
-			heater_ttbllen_map[index]=COUNT(temptable_75);
+				heater_ttbl_map[index]=temptable_75;
+				heater_ttbllen_map[index]=COUNT(temptable_75);
+				heater_sensor_names[index]=THERMISTOR_NAME_75;
 			break;
 			case 8:
-			heater_ttbl_map[index]=temptable_8;
-			heater_ttbllen_map[index]=COUNT(temptable_8);
+				heater_ttbl_map[index]=temptable_8;
+				heater_ttbllen_map[index]=COUNT(temptable_8);
+				heater_sensor_names[index]=THERMISTOR_NAME_8;
 			break;
 			case 9:
-			heater_ttbl_map[index]=temptable_9;
-			heater_ttbllen_map[index]=COUNT(temptable_9);
+				heater_ttbl_map[index]=temptable_9;
+				heater_ttbllen_map[index]=COUNT(temptable_9);
+				heater_sensor_names[index]=THERMISTOR_NAME_9;
 			break;
 			case 998:
-			heater_ttbl_map[index]=temptable_998;
-			heater_ttbllen_map[index]=COUNT(temptable_998);
+				heater_ttbl_map[index]=temptable_998;
+				heater_ttbllen_map[index]=COUNT(temptable_998);
+				heater_sensor_names[index]=THERMISTOR_NAME_998;
 			break;
 			case 999:
-			heater_ttbl_map[index]=temptable_999;
-			heater_ttbllen_map[index]=COUNT(temptable_999);
+				heater_ttbl_map[index]=temptable_999;
+				heater_ttbllen_map[index]=COUNT(temptable_999);
+				heater_sensor_names[index]=THERMISTOR_NAME_999;
 			break;		
 		}
-		
 	}
 	void Temperature::update_bed_ttbl(uint16_t sensorId){
 		switch(sensorId)
@@ -296,126 +326,162 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 			case 1:
 			bedTempTable[0]=temptable_1;
 			bedTempTableLen[0]=COUNT(temptable_1);
+			sensor_name_bed=THERMISTOR_NAME_1;
 			break;
 			case 10:
 			bedTempTable[0]=temptable_10;
 			bedTempTableLen[0]=COUNT(temptable_10);
+			sensor_name_bed=THERMISTOR_NAME_10;
 			break;
 			case 1010:
 			bedTempTable[0]=temptable_1010;
 			bedTempTableLen[0]=COUNT(temptable_1010);
+			sensor_name_bed=THERMISTOR_NAME_1010;
 			break;
 			case 1047:
 			bedTempTable[0]=temptable_1047;
 			bedTempTableLen[0]=COUNT(temptable_1047);
+			sensor_name_bed=THERMISTOR_NAME_1047;
 			break;
 			case 11:
 			bedTempTable[0]=temptable_11;
 			bedTempTableLen[0]=COUNT(temptable_11);
+			sensor_name_bed=THERMISTOR_NAME_11;
 			break;
 			case 110:
 			bedTempTable[0]=temptable_110;
 			bedTempTableLen[0]=COUNT(temptable_110);
+			sensor_name_bed=THERMISTOR_NAME_110;
 			break;
 			case 12:
 			bedTempTable[0]=temptable_12;
 			bedTempTableLen[0]=COUNT(temptable_12);
+			sensor_name_bed=THERMISTOR_NAME_12;
 			break;
 			case 13:
 			bedTempTable[0]=temptable_13;
 			bedTempTableLen[0]=COUNT(temptable_13);
+			sensor_name_bed=THERMISTOR_NAME_13;
 			break;
 			case 147:
 			bedTempTable[0]=temptable_147;
 			bedTempTableLen[0]=COUNT(temptable_147);
+			sensor_name_bed=THERMISTOR_NAME_147;
 			break;
 			case 15:
 			bedTempTable[0]=temptable_15;
 			bedTempTableLen[0]=COUNT(temptable_15);
+			sensor_name_bed=THERMISTOR_NAME_15;
 			break;
 			case 2:
 			bedTempTable[0]=temptable_2;
 			bedTempTableLen[0]=COUNT(temptable_2);
+			sensor_name_bed=THERMISTOR_NAME_2;
 			break;
 			case 20:
 			bedTempTable[0]=temptable_20;
 			bedTempTableLen[0]=COUNT(temptable_20);
+			sensor_name_bed=THERMISTOR_NAME_20;
 			break;
 			case 3:
 			bedTempTable[0]=temptable_3;
 			bedTempTableLen[0]=COUNT(temptable_3);
+			sensor_name_bed=THERMISTOR_NAME_3;
 			break;
 			case 4:
 			bedTempTable[0]=temptable_4;
 			bedTempTableLen[0]=COUNT(temptable_4);
+			sensor_name_bed=THERMISTOR_NAME_4;
 			break;
 			case 5:
 			bedTempTable[0]=temptable_5;
 			bedTempTableLen[0]=COUNT(temptable_5);
+			sensor_name_bed=THERMISTOR_NAME_5;
 			break;
 			case 501:
 			bedTempTable[0]=temptable_501;
 			bedTempTableLen[0]=COUNT(temptable_501);
+			sensor_name_bed=THERMISTOR_NAME_501;
 			break;
 			case 51:
 			bedTempTable[0]=temptable_51;
 			bedTempTableLen[0]=COUNT(temptable_51);
+			sensor_name_bed=THERMISTOR_NAME_51;
 			break;
 			case 52:
 			bedTempTable[0]=temptable_52;
 			bedTempTableLen[0]=COUNT(temptable_52);
+			sensor_name_bed=THERMISTOR_NAME_52;
 			break;
 			case 55:
 			bedTempTable[0]=temptable_55;
 			bedTempTableLen[0]=COUNT(temptable_55);
+			sensor_name_bed=THERMISTOR_NAME_55;
 			break;
 			case 6:
 			bedTempTable[0]=temptable_6;
 			bedTempTableLen[0]=COUNT(temptable_6);
+			sensor_name_bed=THERMISTOR_NAME_6;
 			break;
 			case 60:
 			bedTempTable[0]=temptable_60;
 			bedTempTableLen[0]=COUNT(temptable_60);
+			sensor_name_bed=THERMISTOR_NAME_60;
 			break;
 			case 66:
 			bedTempTable[0]=temptable_66;
 			bedTempTableLen[0]=COUNT(temptable_66);
+			sensor_name_bed=THERMISTOR_NAME_66;
 			break;
 			case 7:
 			bedTempTable[0]=temptable_7;
 			bedTempTableLen[0]=COUNT(temptable_7);
+			sensor_name_bed=THERMISTOR_NAME_7;
 			break;
 			case 70:
 			bedTempTable[0]=temptable_70;
 			bedTempTableLen[0]=COUNT(temptable_70);
+			sensor_name_bed=THERMISTOR_NAME_70;
 			break;
 			case 71:
 			bedTempTable[0]=temptable_71;
 			bedTempTableLen[0]=COUNT(temptable_71);
+			sensor_name_bed=THERMISTOR_NAME_71;
 			break;
 			case 75:
 			bedTempTable[0]=temptable_75;
 			bedTempTableLen[0]=COUNT(temptable_75);
+			sensor_name_bed=THERMISTOR_NAME_75;
 			break;
 			case 8:
 			bedTempTable[0]=temptable_8;
 			bedTempTableLen[0]=COUNT(temptable_8);
+			sensor_name_bed=THERMISTOR_NAME_8;
 			break;
 			case 9:
 			bedTempTable[0]=temptable_9;
 			bedTempTableLen[0]=COUNT(temptable_9);
+			sensor_name_bed=THERMISTOR_NAME_9;
 			break;
 			case 998:
 			bedTempTable[0]=temptable_998;
 			bedTempTableLen[0]=COUNT(temptable_998);
+			sensor_name_bed=THERMISTOR_NAME_998;
 			break;
 			case 999:
 			bedTempTable[0]=temptable_999;
 			bedTempTableLen[0]=COUNT(temptable_999);
+			sensor_name_bed=THERMISTOR_NAME_999;
 			break;
 		}
+
 	}
 	
+	void Temperature::report_sensors_names(){
+				//SERIAL_ECHO_START();
+				//SERIAL_ECHOLNPAIR("Heater 0 sensor:",  )
+				//SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
+	}
 #endif
 #if ENABLED(PREVENT_COLD_EXTRUSION)
   bool Temperature::allow_cold_extrude = false;

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1518,7 +1518,9 @@ float Temperature::analog2temp(const int raw, const uint8_t e) {
   // For chamber temperature measurement.
   float Temperature::analog2tempChamber(const int raw) {
     #if ENABLED(HEATER_CHAMBER_USES_THERMISTOR)
-      SCAN_THERMISTOR_TABLE(CHAMBERTEMPTABLE, CHAMBERTEMPTABLE_LEN);
+	const short(*tt)[][2] = (short(*)[][2])(chamberTempTable[0]);
+	SCAN_THERMISTOR_TABLE((*tt), chamberTempTableLen[0]);
+      //SCAN_THERMISTOR_TABLE(CHAMBERTEMPTABLE, CHAMBERTEMPTABLE_LEN);
     #elif ENABLED(HEATER_CHAMBER_USES_AD595)
       return TEMP_AD595(raw);
     #elif ENABLED(HEATER_CHAMBER_USES_AD8495)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -478,9 +478,25 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 	}
 	
 	void Temperature::report_sensors_names(){
-				//SERIAL_ECHO_START();
-				//SERIAL_ECHOLNPAIR("Heater 0 sensor:",  )
-				//SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
+				SERIAL_ECHO_START();
+				#if THERMISTORHEATER_0
+				SERIAL_ECHOLNPAIR("Heater 0 sensor:",  heater_sensor_names[0]);
+				#endif
+				#if THERMISTORHEATER_1
+				SERIAL_ECHOLNPAIR("Heater 1 sensor:",  heater_sensor_names[1]);
+				#endif
+				#if THERMISTORHEATER_2
+				SERIAL_ECHOLNPAIR("Heater 2 sensor:",  heater_sensor_names[2]);
+				#endif
+				#if THERMISTORHEATER_3
+				SERIAL_ECHOLNPAIR("Heater 3 sensor:",  heater_sensor_names[3]);
+				#endif
+				#if THERMISTORHEATER_4
+				SERIAL_ECHOLNPAIR("Heater 4 sensor:",  heater_sensor_names[4]);
+				#endif
+				#ifdef THERMISTORBED 
+				SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
+				#endif
 	}
 #endif
 #if ENABLED(PREVENT_COLD_EXTRUSION)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -56,15 +56,96 @@
 
 #if HOTEND_USES_THERMISTOR
   #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-    static void* heater_ttbl_map[2] = { (void*)HEATER_0_TEMPTABLE, (void*)HEATER_1_TEMPTABLE };
+    static const void* heater_ttbl_map[2] = { HEATER_0_TEMPTABLE, HEATER_1_TEMPTABLE };
     static uint8_t heater_ttbllen_map[2] = { HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN };
   #else
-    static void* heater_ttbl_map[HOTENDS] = ARRAY_BY_HOTENDS((void*)HEATER_0_TEMPTABLE, (void*)HEATER_1_TEMPTABLE, (void*)HEATER_2_TEMPTABLE, (void*)HEATER_3_TEMPTABLE, (void*)HEATER_4_TEMPTABLE);
+    static const void* heater_ttbl_map[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_TEMPTABLE, HEATER_1_TEMPTABLE, HEATER_2_TEMPTABLE, HEATER_3_TEMPTABLE, HEATER_4_TEMPTABLE);
     static uint8_t heater_ttbllen_map[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN, HEATER_2_TEMPTABLE_LEN, HEATER_3_TEMPTABLE_LEN, HEATER_4_TEMPTABLE_LEN);
-	static char* heater_sensor_names[HOTENDS] = ARRAY_BY_HOTENDS(sensor_name_heater0, sensor_name_heater1, sensor_name_heater2, sensor_name_heater3, sensor_name_heater4);
+    static uint16_t heater_sensor_ids[HOTENDS] = ARRAY_BY_HOTENDS(TEMP_SENSOR_0, TEMP_SENSOR_1, TEMP_SENSOR_2, TEMP_SENSOR_3, TEMP_SENSOR_4);
+    static const char* heater_sensor_names[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_SENSOR_NAME, HEATER_1_SENSOR_NAME, HEATER_2_SENSOR_NAME, HEATER_3_SENSOR_NAME, HEATER_4_SENSOR_NAME);
   #endif
 #endif
 
+#ifdef HEATER_BED_USES_THERMISTOR
+  static const void* bedTempTable = BEDTEMPTABLE;
+  static uint8_t bedTempTableLen = BEDTEMPTABLE_LEN;
+  static uint16_t sensor_id_bed = THERMISTORBED;
+  static const char* sensor_name_bed = BED_SENSOR_NAME;
+#endif
+
+#ifdef HEATER_CHAMBER_USES_THERMISTOR
+  static const void* chamberTempTable = CHAMBERTEMPTABLE;
+  static uint8_t chamberTempTableLen = CHAMBERTEMPTABLE_LEN;
+  static uint16_t sensor_id_chamber = THERMISTORCHAMBER;
+  static const char* sensor_name_chamber = CHAMBER_SENSOR_NAME;
+#endif
+
+//Min temperatures
+static float heater_min_temp_array[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MINTEMP,HEATER_1_MINTEMP,HEATER_2_MINTEMP,HEATER_3_MINTEMP,HEATER_4_MINTEMP);
+static float bed_min_temp = BED_MINTEMP;
+
+//Max temperatures
+static float heater_max_temp_array[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP,HEATER_1_MAXTEMP,HEATER_2_MAXTEMP,HEATER_3_MAXTEMP,HEATER_4_MAXTEMP);
+static float bed_max_temp = BED_MAXTEMP;
+
+#ifdef HEATER_0_MINTEMP
+  #undef HEATER_0_MINTEMP
+  #define HEATER_0_MINTEMP heater_min_temp_array[0]
+#endif
+#ifdef HEATER_0_MAXTEMP
+  #undef HEATER_0_MAXTEMP
+  #define HEATER_0_MAXTEMP heater_max_temp_array[0]
+#endif
+#if HOTENDS > 1
+  #ifdef HEATER_1_MINTEMP
+    #undef HEATER_1_MINTEMP
+    #define HEATER_1_MINTEMP heater_min_temp_array[1]
+  #endif
+  #ifdef HEATER_1_MAXTEMP
+    #undef HEATER_1_MAXTEMP
+    #define HEATER_1_MAXTEMP heater_max_temp_array[1]
+  #endif
+  #if HOTENDS > 2
+    #ifdef HEATER_2_MINTEMP
+      #undef HEATER_2_MINTEMP
+      #define HEATER_2_MINTEMP heater_min_temp_array[2]
+    #endif
+    #ifdef HEATER_2_MAXTEMP
+      #undef HEATER_2_MAXTEMP
+      #define HEATER_2_MAXTEMP heater_max_temp_array[2]
+    #endif
+    #if HOTENDS > 3
+      #ifdef HEATER_3_MINTEMP
+        #undef HEATER_3_MINTEMP
+        #define HEATER_3_MINTEMP heater_min_temp_array[3]
+      #endif
+      #ifdef HEATER_3_MAXTEMP
+        #undef HEATER_3_MAXTEMP
+        #define HEATER_3_MAXTEMP heater_max_temp_array[3]
+      #endif
+      #if HOTENDS > 4
+        #ifdef HEATER_4_MINTEMP
+          #undef HEATER_4_MINTEMP
+          #define HEATER_4_MINTEMP heater_min_temp_array[4]
+        #endif
+        #ifdef HEATER_4_MAXTEMP
+          #undef HEATER_4_MAXTEMP
+          #define HEATER_4_MAXTEMP heater_max_temp_array[4]
+        #endif
+      #endif // HOTENDS > 4
+    #endif // HOTENDS > 3
+  #endif // HOTENDS > 2
+#endif // HOTENDS > 1
+
+#ifdef BED_MINTEMP
+  #undef BED_MINTEMP
+  #define BED_MINTEMP bed_min_temp
+#endif
+
+#ifdef BED_MAXTEMP
+  #undef BED_MAXTEMP
+  #define BED_MAXTEMP bed_max_temp
+#endif
 
 Temperature thermalManager;
 
@@ -166,6 +247,7 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 
 #ifdef BCN3D_MOD
 	void Temperature::update_heater_ttbl_map(int8_t index, uint16_t sensorId){
+		heater_sensor_ids[index]=sensorId;
 		switch(sensorId)
 		{
 			case 1:
@@ -321,156 +403,157 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 		}
 	}
 	void Temperature::update_bed_ttbl(uint16_t sensorId){
+		sensor_id_bed=sensorId;
 		switch(sensorId)
 		{
 			case 1:
-			bedTempTable[0]=temptable_1;
-			bedTempTableLen[0]=COUNT(temptable_1);
+			bedTempTable=temptable_1;
+			bedTempTableLen=COUNT(temptable_1);
 			sensor_name_bed=THERMISTOR_NAME_1;
 			break;
 			case 10:
-			bedTempTable[0]=temptable_10;
-			bedTempTableLen[0]=COUNT(temptable_10);
+			bedTempTable=temptable_10;
+			bedTempTableLen=COUNT(temptable_10);
 			sensor_name_bed=THERMISTOR_NAME_10;
 			break;
 			case 1010:
-			bedTempTable[0]=temptable_1010;
-			bedTempTableLen[0]=COUNT(temptable_1010);
+			bedTempTable=temptable_1010;
+			bedTempTableLen=COUNT(temptable_1010);
 			sensor_name_bed=THERMISTOR_NAME_1010;
 			break;
 			case 1047:
-			bedTempTable[0]=temptable_1047;
-			bedTempTableLen[0]=COUNT(temptable_1047);
+			bedTempTable=temptable_1047;
+			bedTempTableLen=COUNT(temptable_1047);
 			sensor_name_bed=THERMISTOR_NAME_1047;
 			break;
 			case 11:
-			bedTempTable[0]=temptable_11;
-			bedTempTableLen[0]=COUNT(temptable_11);
+			bedTempTable=temptable_11;
+			bedTempTableLen=COUNT(temptable_11);
 			sensor_name_bed=THERMISTOR_NAME_11;
 			break;
 			case 110:
-			bedTempTable[0]=temptable_110;
-			bedTempTableLen[0]=COUNT(temptable_110);
+			bedTempTable=temptable_110;
+			bedTempTableLen=COUNT(temptable_110);
 			sensor_name_bed=THERMISTOR_NAME_110;
 			break;
 			case 12:
-			bedTempTable[0]=temptable_12;
-			bedTempTableLen[0]=COUNT(temptable_12);
+			bedTempTable=temptable_12;
+			bedTempTableLen=COUNT(temptable_12);
 			sensor_name_bed=THERMISTOR_NAME_12;
 			break;
 			case 13:
-			bedTempTable[0]=temptable_13;
-			bedTempTableLen[0]=COUNT(temptable_13);
+			bedTempTable=temptable_13;
+			bedTempTableLen=COUNT(temptable_13);
 			sensor_name_bed=THERMISTOR_NAME_13;
 			break;
 			case 147:
-			bedTempTable[0]=temptable_147;
-			bedTempTableLen[0]=COUNT(temptable_147);
+			bedTempTable=temptable_147;
+			bedTempTableLen=COUNT(temptable_147);
 			sensor_name_bed=THERMISTOR_NAME_147;
 			break;
 			case 15:
-			bedTempTable[0]=temptable_15;
-			bedTempTableLen[0]=COUNT(temptable_15);
+			bedTempTable=temptable_15;
+			bedTempTableLen=COUNT(temptable_15);
 			sensor_name_bed=THERMISTOR_NAME_15;
 			break;
 			case 2:
-			bedTempTable[0]=temptable_2;
-			bedTempTableLen[0]=COUNT(temptable_2);
+			bedTempTable=temptable_2;
+			bedTempTableLen=COUNT(temptable_2);
 			sensor_name_bed=THERMISTOR_NAME_2;
 			break;
 			case 20:
-			bedTempTable[0]=temptable_20;
-			bedTempTableLen[0]=COUNT(temptable_20);
+			bedTempTable=temptable_20;
+			bedTempTableLen=COUNT(temptable_20);
 			sensor_name_bed=THERMISTOR_NAME_20;
 			break;
 			case 3:
-			bedTempTable[0]=temptable_3;
-			bedTempTableLen[0]=COUNT(temptable_3);
+			bedTempTable=temptable_3;
+			bedTempTableLen=COUNT(temptable_3);
 			sensor_name_bed=THERMISTOR_NAME_3;
 			break;
 			case 4:
-			bedTempTable[0]=temptable_4;
-			bedTempTableLen[0]=COUNT(temptable_4);
+			bedTempTable=temptable_4;
+			bedTempTableLen=COUNT(temptable_4);
 			sensor_name_bed=THERMISTOR_NAME_4;
 			break;
 			case 5:
-			bedTempTable[0]=temptable_5;
-			bedTempTableLen[0]=COUNT(temptable_5);
+			bedTempTable=temptable_5;
+			bedTempTableLen=COUNT(temptable_5);
 			sensor_name_bed=THERMISTOR_NAME_5;
 			break;
 			case 501:
-			bedTempTable[0]=temptable_501;
-			bedTempTableLen[0]=COUNT(temptable_501);
+			bedTempTable=temptable_501;
+			bedTempTableLen=COUNT(temptable_501);
 			sensor_name_bed=THERMISTOR_NAME_501;
 			break;
 			case 51:
-			bedTempTable[0]=temptable_51;
-			bedTempTableLen[0]=COUNT(temptable_51);
+			bedTempTable=temptable_51;
+			bedTempTableLen=COUNT(temptable_51);
 			sensor_name_bed=THERMISTOR_NAME_51;
 			break;
 			case 52:
-			bedTempTable[0]=temptable_52;
-			bedTempTableLen[0]=COUNT(temptable_52);
+			bedTempTable=temptable_52;
+			bedTempTableLen=COUNT(temptable_52);
 			sensor_name_bed=THERMISTOR_NAME_52;
 			break;
 			case 55:
-			bedTempTable[0]=temptable_55;
-			bedTempTableLen[0]=COUNT(temptable_55);
+			bedTempTable=temptable_55;
+			bedTempTableLen=COUNT(temptable_55);
 			sensor_name_bed=THERMISTOR_NAME_55;
 			break;
 			case 6:
-			bedTempTable[0]=temptable_6;
-			bedTempTableLen[0]=COUNT(temptable_6);
+			bedTempTable=temptable_6;
+			bedTempTableLen=COUNT(temptable_6);
 			sensor_name_bed=THERMISTOR_NAME_6;
 			break;
 			case 60:
-			bedTempTable[0]=temptable_60;
-			bedTempTableLen[0]=COUNT(temptable_60);
+			bedTempTable=temptable_60;
+			bedTempTableLen=COUNT(temptable_60);
 			sensor_name_bed=THERMISTOR_NAME_60;
 			break;
 			case 66:
-			bedTempTable[0]=temptable_66;
-			bedTempTableLen[0]=COUNT(temptable_66);
+			bedTempTable=temptable_66;
+			bedTempTableLen=COUNT(temptable_66);
 			sensor_name_bed=THERMISTOR_NAME_66;
 			break;
 			case 7:
-			bedTempTable[0]=temptable_7;
-			bedTempTableLen[0]=COUNT(temptable_7);
+			bedTempTable=temptable_7;
+			bedTempTableLen=COUNT(temptable_7);
 			sensor_name_bed=THERMISTOR_NAME_7;
 			break;
 			case 70:
-			bedTempTable[0]=temptable_70;
-			bedTempTableLen[0]=COUNT(temptable_70);
+			bedTempTable=temptable_70;
+			bedTempTableLen=COUNT(temptable_70);
 			sensor_name_bed=THERMISTOR_NAME_70;
 			break;
 			case 71:
-			bedTempTable[0]=temptable_71;
-			bedTempTableLen[0]=COUNT(temptable_71);
+			bedTempTable=temptable_71;
+			bedTempTableLen=COUNT(temptable_71);
 			sensor_name_bed=THERMISTOR_NAME_71;
 			break;
 			case 75:
-			bedTempTable[0]=temptable_75;
-			bedTempTableLen[0]=COUNT(temptable_75);
+			bedTempTable=temptable_75;
+			bedTempTableLen=COUNT(temptable_75);
 			sensor_name_bed=THERMISTOR_NAME_75;
 			break;
 			case 8:
-			bedTempTable[0]=temptable_8;
-			bedTempTableLen[0]=COUNT(temptable_8);
+			bedTempTable=temptable_8;
+			bedTempTableLen=COUNT(temptable_8);
 			sensor_name_bed=THERMISTOR_NAME_8;
 			break;
 			case 9:
-			bedTempTable[0]=temptable_9;
-			bedTempTableLen[0]=COUNT(temptable_9);
+			bedTempTable=temptable_9;
+			bedTempTableLen=COUNT(temptable_9);
 			sensor_name_bed=THERMISTOR_NAME_9;
 			break;
 			case 998:
-			bedTempTable[0]=temptable_998;
-			bedTempTableLen[0]=COUNT(temptable_998);
+			bedTempTable=temptable_998;
+			bedTempTableLen=COUNT(temptable_998);
 			sensor_name_bed=THERMISTOR_NAME_998;
 			break;
 			case 999:
-			bedTempTable[0]=temptable_999;
-			bedTempTableLen[0]=COUNT(temptable_999);
+			bedTempTable=temptable_999;
+			bedTempTableLen=COUNT(temptable_999);
 			sensor_name_bed=THERMISTOR_NAME_999;
 			break;
 		}
@@ -478,156 +561,157 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 	}
 	
 	void Temperature::update_chamber_ttbl(uint16_t sensorId){
+		sensor_id_chamber=sensorId;
 		switch(sensorId)
 		{
 			case 1:
-			chamberTempTable[0]=temptable_1;
-			chamberTempTableLen[0]=COUNT(temptable_1);
+			chamberTempTable=temptable_1;
+			chamberTempTableLen=COUNT(temptable_1);
 			sensor_name_chamber=THERMISTOR_NAME_1;
 			break;
 			case 10:
-			chamberTempTable[0]=temptable_10;
-			chamberTempTableLen[0]=COUNT(temptable_10);
+			chamberTempTable=temptable_10;
+			chamberTempTableLen=COUNT(temptable_10);
 			sensor_name_chamber=THERMISTOR_NAME_10;
 			break;
 			case 1010:
-			chamberTempTable[0]=temptable_1010;
-			chamberTempTableLen[0]=COUNT(temptable_1010);
+			chamberTempTable=temptable_1010;
+			chamberTempTableLen=COUNT(temptable_1010);
 			sensor_name_chamber=THERMISTOR_NAME_1010;
 			break;
 			case 1047:
-			chamberTempTable[0]=temptable_1047;
-			chamberTempTableLen[0]=COUNT(temptable_1047);
+			chamberTempTable=temptable_1047;
+			chamberTempTableLen=COUNT(temptable_1047);
 			sensor_name_chamber=THERMISTOR_NAME_1047;
 			break;
 			case 11:
-			chamberTempTable[0]=temptable_11;
-			chamberTempTableLen[0]=COUNT(temptable_11);
+			chamberTempTable=temptable_11;
+			chamberTempTableLen=COUNT(temptable_11);
 			sensor_name_chamber=THERMISTOR_NAME_11;
 			break;
 			case 110:
-			chamberTempTable[0]=temptable_110;
-			chamberTempTableLen[0]=COUNT(temptable_110);
+			chamberTempTable=temptable_110;
+			chamberTempTableLen=COUNT(temptable_110);
 			sensor_name_chamber=THERMISTOR_NAME_110;
 			break;
 			case 12:
-			chamberTempTable[0]=temptable_12;
-			chamberTempTableLen[0]=COUNT(temptable_12);
+			chamberTempTable=temptable_12;
+			chamberTempTableLen=COUNT(temptable_12);
 			sensor_name_chamber=THERMISTOR_NAME_12;
 			break;
 			case 13:
-			chamberTempTable[0]=temptable_13;
-			chamberTempTableLen[0]=COUNT(temptable_13);
+			chamberTempTable=temptable_13;
+			chamberTempTableLen=COUNT(temptable_13);
 			sensor_name_chamber=THERMISTOR_NAME_13;
 			break;
 			case 147:
-			chamberTempTable[0]=temptable_147;
-			chamberTempTableLen[0]=COUNT(temptable_147);
+			chamberTempTable=temptable_147;
+			chamberTempTableLen=COUNT(temptable_147);
 			sensor_name_chamber=THERMISTOR_NAME_147;
 			break;
 			case 15:
-			chamberTempTable[0]=temptable_15;
-			chamberTempTableLen[0]=COUNT(temptable_15);
+			chamberTempTable=temptable_15;
+			chamberTempTableLen=COUNT(temptable_15);
 			sensor_name_chamber=THERMISTOR_NAME_15;
 			break;
 			case 2:
-			chamberTempTable[0]=temptable_2;
-			chamberTempTableLen[0]=COUNT(temptable_2);
+			chamberTempTable=temptable_2;
+			chamberTempTableLen=COUNT(temptable_2);
 			sensor_name_chamber=THERMISTOR_NAME_2;
 			break;
 			case 20:
-			chamberTempTable[0]=temptable_20;
-			chamberTempTableLen[0]=COUNT(temptable_20);
+			chamberTempTable=temptable_20;
+			chamberTempTableLen=COUNT(temptable_20);
 			sensor_name_chamber=THERMISTOR_NAME_20;
 			break;
 			case 3:
-			chamberTempTable[0]=temptable_3;
-			chamberTempTableLen[0]=COUNT(temptable_3);
+			chamberTempTable=temptable_3;
+			chamberTempTableLen=COUNT(temptable_3);
 			sensor_name_chamber=THERMISTOR_NAME_3;
 			break;
 			case 4:
-			chamberTempTable[0]=temptable_4;
-			chamberTempTableLen[0]=COUNT(temptable_4);
+			chamberTempTable=temptable_4;
+			chamberTempTableLen=COUNT(temptable_4);
 			sensor_name_chamber=THERMISTOR_NAME_4;
 			break;
 			case 5:
-			chamberTempTable[0]=temptable_5;
-			chamberTempTableLen[0]=COUNT(temptable_5);
+			chamberTempTable=temptable_5;
+			chamberTempTableLen=COUNT(temptable_5);
 			sensor_name_chamber=THERMISTOR_NAME_5;
 			break;
 			case 501:
-			chamberTempTable[0]=temptable_501;
-			chamberTempTableLen[0]=COUNT(temptable_501);
+			chamberTempTable=temptable_501;
+			chamberTempTableLen=COUNT(temptable_501);
 			sensor_name_chamber=THERMISTOR_NAME_501;
 			break;
 			case 51:
-			chamberTempTable[0]=temptable_51;
-			chamberTempTableLen[0]=COUNT(temptable_51);
+			chamberTempTable=temptable_51;
+			chamberTempTableLen=COUNT(temptable_51);
 			sensor_name_chamber=THERMISTOR_NAME_51;
 			break;
 			case 52:
-			chamberTempTable[0]=temptable_52;
-			chamberTempTableLen[0]=COUNT(temptable_52);
+			chamberTempTable=temptable_52;
+			chamberTempTableLen=COUNT(temptable_52);
 			sensor_name_chamber=THERMISTOR_NAME_52;
 			break;
 			case 55:
-			chamberTempTable[0]=temptable_55;
-			chamberTempTableLen[0]=COUNT(temptable_55);
+			chamberTempTable=temptable_55;
+			chamberTempTableLen=COUNT(temptable_55);
 			sensor_name_chamber=THERMISTOR_NAME_55;
 			break;
 			case 6:
-			chamberTempTable[0]=temptable_6;
-			chamberTempTableLen[0]=COUNT(temptable_6);
+			chamberTempTable=temptable_6;
+			chamberTempTableLen=COUNT(temptable_6);
 			sensor_name_chamber=THERMISTOR_NAME_6;
 			break;
 			case 60:
-			chamberTempTable[0]=temptable_60;
-			chamberTempTableLen[0]=COUNT(temptable_60);
+			chamberTempTable=temptable_60;
+			chamberTempTableLen=COUNT(temptable_60);
 			sensor_name_chamber=THERMISTOR_NAME_60;
 			break;
 			case 66:
-			chamberTempTable[0]=temptable_66;
-			chamberTempTableLen[0]=COUNT(temptable_66);
+			chamberTempTable=temptable_66;
+			chamberTempTableLen=COUNT(temptable_66);
 			sensor_name_chamber=THERMISTOR_NAME_66;
 			break;
 			case 7:
-			chamberTempTable[0]=temptable_7;
-			chamberTempTableLen[0]=COUNT(temptable_7);
+			chamberTempTable=temptable_7;
+			chamberTempTableLen=COUNT(temptable_7);
 			sensor_name_chamber=THERMISTOR_NAME_7;
 			break;
 			case 70:
-			chamberTempTable[0]=temptable_70;
-			chamberTempTableLen[0]=COUNT(temptable_70);
+			chamberTempTable=temptable_70;
+			chamberTempTableLen=COUNT(temptable_70);
 			sensor_name_chamber=THERMISTOR_NAME_70;
 			break;
 			case 71:
-			chamberTempTable[0]=temptable_71;
-			chamberTempTableLen[0]=COUNT(temptable_71);
+			chamberTempTable=temptable_71;
+			chamberTempTableLen=COUNT(temptable_71);
 			sensor_name_chamber=THERMISTOR_NAME_71;
 			break;
 			case 75:
-			chamberTempTable[0]=temptable_75;
-			chamberTempTableLen[0]=COUNT(temptable_75);
+			chamberTempTable=temptable_75;
+			chamberTempTableLen=COUNT(temptable_75);
 			sensor_name_chamber=THERMISTOR_NAME_75;
 			break;
 			case 8:
-			chamberTempTable[0]=temptable_8;
-			chamberTempTableLen[0]=COUNT(temptable_8);
+			chamberTempTable=temptable_8;
+			chamberTempTableLen=COUNT(temptable_8);
 			sensor_name_chamber=THERMISTOR_NAME_8;
 			break;
 			case 9:
-			chamberTempTable[0]=temptable_9;
-			chamberTempTableLen[0]=COUNT(temptable_9);
+			chamberTempTable=temptable_9;
+			chamberTempTableLen=COUNT(temptable_9);
 			sensor_name_chamber=THERMISTOR_NAME_9;
 			break;
 			case 998:
-			chamberTempTable[0]=temptable_998;
-			chamberTempTableLen[0]=COUNT(temptable_998);
+			chamberTempTable=temptable_998;
+			chamberTempTableLen=COUNT(temptable_998);
 			sensor_name_chamber=THERMISTOR_NAME_998;
 			break;
 			case 999:
-			bedTempTable[0]=temptable_999;
-			bedTempTableLen[0]=COUNT(temptable_999);
+			bedTempTable=temptable_999;
+			bedTempTableLen=COUNT(temptable_999);
 			sensor_name_bed=THERMISTOR_NAME_999;
 			break;
 		}
@@ -635,29 +719,171 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 	}
 	
 	void Temperature::report_sensors_names(){
-				SERIAL_ECHO_START();
-				#if THERMISTORHEATER_0
-				SERIAL_ECHOLNPAIR("Heater 0 sensor:",  heater_sensor_names[0]);
-				#endif
-				#if THERMISTORHEATER_1
-				SERIAL_ECHOLNPAIR("Heater 1 sensor:",  heater_sensor_names[1]);
-				#endif
-				#if THERMISTORHEATER_2
-				SERIAL_ECHOLNPAIR("Heater 2 sensor:",  heater_sensor_names[2]);
-				#endif
-				#if THERMISTORHEATER_3
-				SERIAL_ECHOLNPAIR("Heater 3 sensor:",  heater_sensor_names[3]);
-				#endif
-				#if THERMISTORHEATER_4
-				SERIAL_ECHOLNPAIR("Heater 4 sensor:",  heater_sensor_names[4]);
-				#endif
-				#ifdef THERMISTORBED 
-				SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
-				#endif
-				#ifdef THERMISTORCHAMBER
-				SERIAL_ECHOLNPAIR("Chamber sensor: ", sensor_name_chamber);
-				#endif
+		#if THERMISTORHEATER_0
+		SERIAL_ECHOLNPAIR("Heater 0 sensor:",  heater_sensor_names[0]);
+		#endif
+		#if THERMISTORHEATER_1
+		SERIAL_ECHOLNPAIR("Heater 1 sensor:",  heater_sensor_names[1]);
+		#endif
+		#if THERMISTORHEATER_2
+		SERIAL_ECHOLNPAIR("Heater 2 sensor:",  heater_sensor_names[2]);
+		#endif
+		#if THERMISTORHEATER_3
+		SERIAL_ECHOLNPAIR("Heater 3 sensor:",  heater_sensor_names[3]);
+		#endif
+		#if THERMISTORHEATER_4
+		SERIAL_ECHOLNPAIR("Heater 4 sensor:",  heater_sensor_names[4]);
+		#endif
+		#ifdef THERMISTORBED 
+		SERIAL_ECHOLNPAIR("Bed sensor: ", sensor_name_bed);
+		#endif
+		#ifdef THERMISTORCHAMBER
+		SERIAL_ECHOLNPAIR("Chamber sensor: ", sensor_name_chamber);
+		#endif
 	}
+
+  uint16_t Temperature::get_heater_sensor_id(int8_t index) {
+    return heater_sensor_ids[index];
+  }
+
+  void Temperature::set_heater_min_temp(int8_t index, float value) {
+    switch (index)
+    {
+    case 0:
+      HEATER_0_MINTEMP = value;
+      break;
+    #if HOTENDS > 1
+      case 1:
+        HEATER_1_MINTEMP = value;
+        break;
+      #if HOTENDS > 2
+        case 2:
+          HEATER_2_MINTEMP = value;
+          break;
+        #if HOTENDS > 3
+          case 3:
+            HEATER_3_MINTEMP = value;
+            break;
+          #if HOTENDS > 4
+            case 4:
+              HEATER_4_MINTEMP = value;
+              break;
+          #endif // HOTENDS > 4
+        #endif // HOTENDS > 3
+      #endif // HOTENDS > 2
+    #endif // HOTENDS > 1
+    default:
+      break;
+    }
+  }
+
+  float Temperature::get_heater_min_temp(int8_t index) {
+    switch (index)
+    {
+    case 0:
+      return HEATER_0_MINTEMP;
+    #if HOTENDS > 1
+      case 1:
+        return HEATER_1_MINTEMP;
+      #if HOTENDS > 2
+        case 2:
+          return HEATER_2_MINTEMP;
+        #if HOTENDS > 3
+          case 3:
+            return HEATER_3_MINTEMP;
+          #if HOTENDS > 4
+            case 4:
+              return HEATER_4_MINTEMP;
+          #endif // HOTENDS > 4
+        #endif // HOTENDS > 3
+      #endif // HOTENDS > 2
+    #endif // HOTENDS > 1
+    default:
+      return 0.0;
+    }
+  }
+
+  void Temperature::set_heater_max_temp(int8_t index, float value) {
+    switch (index)
+    {
+    case 0:
+      HEATER_0_MAXTEMP = value;
+      break;
+    #if HOTENDS > 1
+      case 1:
+        HEATER_1_MAXTEMP = value;
+        break;
+      #if HOTENDS > 2
+        case 2:
+          HEATER_2_MAXTEMP = value;
+          break;
+        #if HOTENDS > 3
+          case 3:
+            HEATER_3_MAXTEMP = value;
+            break;
+          #if HOTENDS > 4
+            case 4:
+              HEATER_4_MAXTEMP = value;
+              break;
+          #endif // HOTENDS > 4
+        #endif // HOTENDS > 3
+      #endif // HOTENDS > 2
+    #endif // HOTENDS > 1
+    default:
+      break;
+    }
+  }
+
+  float Temperature::get_heater_max_temp(int8_t index) {
+    switch (index)
+    {
+    case 0:
+      return HEATER_0_MAXTEMP;
+    #if HOTENDS > 1
+      case 1:
+        return HEATER_1_MAXTEMP;
+      #if HOTENDS > 2
+        case 2:
+          return HEATER_2_MAXTEMP;
+        #if HOTENDS > 3
+          case 3:
+            return HEATER_3_MAXTEMP;
+          #if HOTENDS > 4
+            case 4:
+              return HEATER_4_MAXTEMP;
+          #endif // HOTENDS > 4
+        #endif // HOTENDS > 3
+      #endif // HOTENDS > 2
+    #endif // HOTENDS > 1
+    default:
+      return 0.0;
+    }
+  }
+
+  uint16_t Temperature::get_bed_sensor_id() {
+    return sensor_id_bed;
+  }
+
+  void Temperature::set_bed_min_temp(float value) {
+    BED_MINTEMP = value;
+  }
+
+  float Temperature::get_bed_min_temp() {
+    return BED_MINTEMP;
+  }
+
+  void Temperature::set_bed_max_temp(float value) {
+    BED_MAXTEMP = value;
+  }
+
+  float Temperature::get_bed_max_temp() {
+    return BED_MAXTEMP;
+  }
+
+  uint16_t Temperature::get_chamber_sensor_id() {
+    return sensor_id_chamber;
+  }
+
 #endif
 #if ENABLED(PREVENT_COLD_EXTRUSION)
   bool Temperature::allow_cold_extrude = false;
@@ -1500,8 +1726,8 @@ float Temperature::analog2temp(const int raw, const uint8_t e) {
   // For bed temperature measurement.
   float Temperature::analog2tempBed(const int raw) {
     #if ENABLED(HEATER_BED_USES_THERMISTOR)
-	const short(*tt)[][2] = (short(*)[][2])(bedTempTable[0]);
-      SCAN_THERMISTOR_TABLE((*tt), bedTempTableLen[0]);
+	const short(*tt)[][2] = (short(*)[][2])(bedTempTable);
+      SCAN_THERMISTOR_TABLE((*tt), bedTempTableLen);
 	 //SCAN_THERMISTOR_TABLE((BEDTEMPTABLE), BEDTEMPTABLE_LEN);
     #elif ENABLED(HEATER_BED_USES_AD595)
       return TEMP_AD595(raw);
@@ -1518,8 +1744,8 @@ float Temperature::analog2temp(const int raw, const uint8_t e) {
   // For chamber temperature measurement.
   float Temperature::analog2tempChamber(const int raw) {
     #if ENABLED(HEATER_CHAMBER_USES_THERMISTOR)
-	const short(*tt)[][2] = (short(*)[][2])(chamberTempTable[0]);
-	SCAN_THERMISTOR_TABLE((*tt), chamberTempTableLen[0]);
+	const short(*tt)[][2] = (short(*)[][2])(chamberTempTable);
+	SCAN_THERMISTOR_TABLE((*tt), chamberTempTableLen);
       //SCAN_THERMISTOR_TABLE(CHAMBERTEMPTABLE, CHAMBERTEMPTABLE_LEN);
     #elif ENABLED(HEATER_CHAMBER_USES_AD595)
       return TEMP_AD595(raw);
@@ -1957,6 +2183,25 @@ void Temperature::init() {
       watch_bed_next_ms = 0;
   }
 #endif
+
+void Temperature::setTargetHotend(const int16_t celsius, const uint8_t e) {
+  #if HOTENDS == 1
+    UNUSED(e);
+  #endif
+  #ifdef MILLISECONDS_PREHEAT_TIME
+    if (celsius == 0)
+      reset_preheat_time(HOTEND_INDEX);
+    else if (target_temperature[HOTEND_INDEX] == 0)
+      start_preheat_time(HOTEND_INDEX);
+  #endif
+  #if ENABLED(AUTO_POWER_CONTROL)
+    powerManager.power_on();
+  #endif
+  target_temperature[HOTEND_INDEX] =  MIN(celsius, heater_max_temp_array[HOTEND_INDEX]);
+  #if WATCH_HOTENDS
+    start_watching_heater(HOTEND_INDEX);
+  #endif
+}
 
 #if ENABLED(THERMAL_PROTECTION_HOTENDS) || HAS_THERMALLY_PROTECTED_BED
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -57,10 +57,10 @@
 #if HOTEND_USES_THERMISTOR
   #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
     static void* heater_ttbl_map[2] = { (void*)HEATER_0_TEMPTABLE, (void*)HEATER_1_TEMPTABLE };
-    static constexpr uint8_t heater_ttbllen_map[2] = { HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN };
+    static uint8_t heater_ttbllen_map[2] = { HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN };
   #else
     static void* heater_ttbl_map[HOTENDS] = ARRAY_BY_HOTENDS((void*)HEATER_0_TEMPTABLE, (void*)HEATER_1_TEMPTABLE, (void*)HEATER_2_TEMPTABLE, (void*)HEATER_3_TEMPTABLE, (void*)HEATER_4_TEMPTABLE);
-    static constexpr uint8_t heater_ttbllen_map[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN, HEATER_2_TEMPTABLE_LEN, HEATER_3_TEMPTABLE_LEN, HEATER_4_TEMPTABLE_LEN);
+    static uint8_t heater_ttbllen_map[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN, HEATER_2_TEMPTABLE_LEN, HEATER_3_TEMPTABLE_LEN, HEATER_4_TEMPTABLE_LEN);
   #endif
 #endif
 
@@ -162,6 +162,202 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
   millis_t Temperature::watch_heater_next_ms[HOTENDS] = { 0 };
 #endif
 
+#ifdef BCN3D_MOD
+	void Temperature::update_heater_ttbl_map(uint8_t index, uint16_t sensorId){
+		switch(sensorId)
+		{
+			case 1:
+				heater_ttbl_map[index]=temptable_1;
+			break;
+			case 10:
+				heater_ttbl_map[index]=temptable_10;
+			break;
+			case 1010:
+				heater_ttbl_map[index]=temptable_1010;
+			break;
+			case 1047:
+				heater_ttbl_map[index]=temptable_1047;
+			break;
+			case 11:
+			heater_ttbl_map[index]=temptable_11;
+			break;
+			case 110:
+			heater_ttbl_map[index]=temptable_110;
+			break;
+			case 12:
+			heater_ttbl_map[index]=temptable_12;
+			break;
+			case 13:
+			heater_ttbl_map[index]=temptable_13;
+			break;
+			case 147:
+			heater_ttbl_map[index]=temptable_147;
+			break;
+			case 15:
+			heater_ttbl_map[index]=temptable_15;
+			break;
+			case 2:
+			heater_ttbl_map[index]=temptable_2;
+			break;
+			case 20:
+			heater_ttbl_map[index]=temptable_20;
+			break;
+			case 3:
+			heater_ttbl_map[index]=temptable_3;
+			break;
+			case 4:
+			heater_ttbl_map[index]=temptable_4;
+			break;
+			case 5:
+			heater_ttbl_map[index]=temptable_5;
+			break;
+			case 501:
+			heater_ttbl_map[index]=temptable_501;
+			break;
+			case 51:
+			heater_ttbl_map[index]=temptable_51;
+			break;
+			case 52:
+			heater_ttbl_map[index]=temptable_52;
+			break;
+			case 55:
+			heater_ttbl_map[index]=temptable_55;
+			break;
+			case 6:
+			heater_ttbl_map[index]=temptable_6;
+			break;
+			case 60:
+			heater_ttbl_map[index]=temptable_60;
+			break;
+			case 66:
+			heater_ttbl_map[index]=temptable_66;
+			break;
+			case 7:
+			heater_ttbl_map[index]=temptable_7;
+			break;
+			case 70:
+			heater_ttbl_map[index]=temptable_70;
+			break;
+			case 71:
+			heater_ttbl_map[index]=temptable_71;
+			break;
+			case 75:
+			heater_ttbl_map[index]=temptable_75;
+			break;
+			case 8:
+			heater_ttbl_map[index]=temptable_8;
+			break;
+			case 9:
+			heater_ttbl_map[index]=temptable_9;
+			break;
+			case 998:
+			heater_ttbl_map[index]=temptable_998;
+			break;
+			case 999:
+			heater_ttbl_map[index]=temptable_999;
+			break;		
+		}
+		heater_ttbllen_map[index]=COUNT(&heater_ttbl_map[index]);
+	}
+	void Temperature::update_bed_ttbl(uint16_t sensorId){
+		switch(sensorId)
+		{
+			case 1:
+			bedTempTable=temptable_1;
+			
+			break;
+			case 10:
+			bedTempTable=temptable_10;
+			break;
+			case 1010:
+			bedTempTable=temptable_1010;
+			break;
+			case 1047:
+			bedTempTable=temptable_1047;
+			break;
+			case 11:
+			bedTempTable=temptable_11;
+			break;
+			case 110:
+			bedTempTable=temptable_110;
+			break;
+			case 12:
+			bedTempTable=temptable_12;
+			break;
+			case 13:
+			bedTempTable=temptable_13;
+			break;
+			case 147:
+			bedTempTable=temptable_147;
+			break;
+			case 15:
+			bedTempTable=temptable_15;
+			break;
+			case 2:
+			bedTempTable=temptable_2;
+			break;
+			case 20:
+			bedTempTable=temptable_20;
+			break;
+			case 3:
+			bedTempTable=temptable_3;
+			break;
+			case 4:
+			bedTempTable=temptable_4;
+			break;
+			case 5:
+			bedTempTable=temptable_5;
+			break;
+			case 501:
+			bedTempTable=temptable_501;
+			break;
+			case 51:
+			bedTempTable=temptable_51;
+			break;
+			case 52:
+			bedTempTable=temptable_52;
+			break;
+			case 55:
+			bedTempTable=temptable_55;
+			break;
+			case 6:
+			bedTempTable=temptable_6;
+			break;
+			case 60:
+			bedTempTable=temptable_60;
+			break;
+			case 66:
+			bedTempTable=temptable_66;
+			break;
+			case 7:
+			bedTempTable=temptable_7;
+			break;
+			case 70:
+			bedTempTable=temptable_70;
+			break;
+			case 71:
+			bedTempTable=temptable_71;
+			break;
+			case 75:
+			bedTempTable=temptable_75;
+			break;
+			case 8:
+			bedTempTable=temptable_8;
+			break;
+			case 9:
+			bedTempTable=temptable_9;
+			break;
+			case 998:
+			bedTempTable=temptable_998;
+			break;
+			case 999:
+			bedTempTable=temptable_999;
+			break;
+		}
+		bedTempTableLen = COUNT(&bedTempTable);
+	}
+	
+#endif
 #if ENABLED(PREVENT_COLD_EXTRUSION)
   bool Temperature::allow_cold_extrude = false;
   int16_t Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
@@ -1003,7 +1199,8 @@ float Temperature::analog2temp(const int raw, const uint8_t e) {
   // For bed temperature measurement.
   float Temperature::analog2tempBed(const int raw) {
     #if ENABLED(HEATER_BED_USES_THERMISTOR)
-      SCAN_THERMISTOR_TABLE(BEDTEMPTABLE, BEDTEMPTABLE_LEN);
+	const short(*tt)[][2] = (short(*)[][2])(bedTempTable);
+      SCAN_THERMISTOR_TABLE((*tt), bedTempTableLen);
     #elif ENABLED(HEATER_BED_USES_AD595)
       return TEMP_AD595(raw);
     #elif ENABLED(HEATER_BED_USES_AD8495)

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -196,7 +196,7 @@ class Temperature {
     FORCE_INLINE static bool targetHotEnoughToExtrude(const uint8_t e) { return !targetTooColdToExtrude(e); }
 		
 	#ifdef BCN3D_MOD
-	static void update_heater_ttbl_map(uint8_t index, uint16_t sensorId);
+	static void update_heater_ttbl_map(int8_t index, uint16_t sensorId);
 	static void update_bed_ttbl(uint16_t sensorId);
 	#endif
   private:

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -420,7 +420,7 @@ class Temperature {
       #if ENABLED(AUTO_POWER_CONTROL)
         powerManager.power_on();
       #endif
-      target_temperature[HOTEND_INDEX] = celsius;
+      target_temperature[HOTEND_INDEX] =  MIN(celsius, max_temp_array[HOTEND_INDEX]);
       #if WATCH_HOTENDS
         start_watching_heater(HOTEND_INDEX);
       #endif

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -198,6 +198,7 @@ class Temperature {
 	#ifdef BCN3D_MOD
 	static void update_heater_ttbl_map(int8_t index, uint16_t sensorId);
 	static void update_bed_ttbl(uint16_t sensorId);
+	static void update_chamber_ttbl(uint16_t sensorId);
 	static void report_sensors_names();
 	#endif
   private:

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -198,6 +198,7 @@ class Temperature {
 	#ifdef BCN3D_MOD
 	static void update_heater_ttbl_map(int8_t index, uint16_t sensorId);
 	static void update_bed_ttbl(uint16_t sensorId);
+	static void report_sensors_names();
 	#endif
   private:
 

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -194,7 +194,11 @@ class Temperature {
 
     FORCE_INLINE static bool hotEnoughToExtrude(const uint8_t e) { return !tooColdToExtrude(e); }
     FORCE_INLINE static bool targetHotEnoughToExtrude(const uint8_t e) { return !targetTooColdToExtrude(e); }
-
+		
+	#ifdef BCN3D_MOD
+	static void update_heater_ttbl_map(uint8_t index, uint16_t sensorId);
+	static void update_bed_ttbl(uint16_t sensorId);
+	#endif
   private:
 
     static volatile bool temp_meas_ready;

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -196,10 +196,21 @@ class Temperature {
     FORCE_INLINE static bool targetHotEnoughToExtrude(const uint8_t e) { return !targetTooColdToExtrude(e); }
 		
 	#ifdef BCN3D_MOD
-	static void update_heater_ttbl_map(int8_t index, uint16_t sensorId);
-	static void update_bed_ttbl(uint16_t sensorId);
-	static void update_chamber_ttbl(uint16_t sensorId);
-	static void report_sensors_names();
+  static void update_heater_ttbl_map(int8_t index, uint16_t sensorId);
+  static void update_bed_ttbl(uint16_t sensorId);
+  static void update_chamber_ttbl(uint16_t sensorId);
+  static void report_sensors_names();
+  static uint16_t get_heater_sensor_id(int8_t index);
+  static void set_heater_min_temp(int8_t index, float value);
+  static float get_heater_min_temp(int8_t index);
+  static void set_heater_max_temp(int8_t index, float value);
+  static float get_heater_max_temp(int8_t index);
+  static uint16_t get_bed_sensor_id();
+  static void set_bed_min_temp(float value);
+  static float get_bed_min_temp();
+  static void set_bed_max_temp(float value);
+  static float get_bed_max_temp();
+  static uint16_t get_chamber_sensor_id();
 	#endif
   private:
 
@@ -271,7 +282,7 @@ class Temperature {
     #if HAS_TEMP_CHAMBER
       static uint16_t raw_temp_chamber_value;
       static float current_temperature_chamber;
-	  static int16_t target_temperature_chamber;
+	    static int16_t target_temperature_chamber;
       static int16_t current_temperature_chamber_raw;
     #endif
 
@@ -408,24 +419,7 @@ class Temperature {
       static void start_watching_heater(const uint8_t e = 0);
     #endif
 
-    static void setTargetHotend(const int16_t celsius, const uint8_t e) {
-      #if HOTENDS == 1
-        UNUSED(e);
-      #endif
-      #ifdef MILLISECONDS_PREHEAT_TIME
-        if (celsius == 0)
-          reset_preheat_time(HOTEND_INDEX);
-        else if (target_temperature[HOTEND_INDEX] == 0)
-          start_preheat_time(HOTEND_INDEX);
-      #endif
-      #if ENABLED(AUTO_POWER_CONTROL)
-        powerManager.power_on();
-      #endif
-      target_temperature[HOTEND_INDEX] =  MIN(celsius, max_temp_array[HOTEND_INDEX]);
-      #if WATCH_HOTENDS
-        start_watching_heater(HOTEND_INDEX);
-      #endif
-    }
+    static void setTargetHotend(const int16_t celsius, const uint8_t e);
 
     FORCE_INLINE static bool isHeatingHotend(const uint8_t e) {
       #if HOTENDS == 1

--- a/Marlin/thermistornames.h
+++ b/Marlin/thermistornames.h
@@ -100,81 +100,115 @@
 
 // Thermcouples
 
-#define THERMISTOR_NAME_AD8495 "AD8495"
+const char* const thermistor_name_AD8495 = "AD8495";
+#define THERMISTOR_NAME_AD8495 thermistor_name_AD8495
 
-#define THERMISTOR_NAME_MAX31855 "MAX31855"
+const char* const thermistor_name_MAX31855 = "MAX31855";
+#define THERMISTOR_NAME_MAX31855 thermistor_name_MAX31855
 
-#define THERMISTOR_NAME_MAX6675 "MAX6675"
+const char* const thermistor_name_MAX6675 = "MAX6675";
+#define THERMISTOR_NAME_MAX6675 thermistor_name_MAX6675
 
-#define THERMISTOR_NAME_AD595 "AD595"
+const char* const thermistor_name_AD595 = "AD595";
+#define THERMISTOR_NAME_AD595 thermistor_name_AD595
 
 // Standard thermistors
 
-#define THERMISTOR_NAME_1 "EPCOS 100K"
+const char* const thermistor_name_1 = "EPCOS 100K";
+#define THERMISTOR_NAME_1 thermistor_name_1
 
-#define THERMISTOR_NAME_2 "ATC 204GT-2"
+const char* const thermistor_name_2 = "ATC 204GT-2";
+#define THERMISTOR_NAME_2 thermistor_name_2
 
-#define THERMISTOR_NAME_3 "Mendel-parts"
+const char* const thermistor_name_3 = "Mendel-parts";
+#define THERMISTOR_NAME_3 thermistor_name_3
 
-#define THERMISTOR_NAME_4 "Generic 10K"
+const char* const thermistor_name_4 = "Generic 10K";
+#define THERMISTOR_NAME_4 thermistor_name_4
 
-#define THERMISTOR_NAME_5 "ATC 104GT-2"
+const char* const thermistor_name_5 = "ATC 104GT-2";
+#define THERMISTOR_NAME_5 thermistor_name_5
 
-#define THERMISTOR_NAME_6 "EPCOS (alt)"
+const char* const thermistor_name_6 = "EPCOS (alt)";
+#define THERMISTOR_NAME_6 thermistor_name_6
 
-#define THERMISTOR_NAME_7 "Honeywell 104LAG"
+const char* const thermistor_name_7 = "Honeywell 104LAG";
+#define THERMISTOR_NAME_7 thermistor_name_7
 
-#define THERMISTOR_NAME_71 "Honeywell 104LAF"
+const char* const thermistor_name_71 = "Honeywell 104LAF";
+#define THERMISTOR_NAME_71 thermistor_name_71
 
-#define THERMISTOR_NAME_8 "E3104FHT"
+const char* const thermistor_name_8 = "E3104FHT";
+#define THERMISTOR_NAME_8 thermistor_name_8
 
-#define THERMISTOR_NAME_9 "GE AL03006"
+const char* const thermistor_name_9 = "GE AL03006";
+#define THERMISTOR_NAME_9 thermistor_name_9
 
-#define THERMISTOR_NAME_10 "RS 198-961"
+const char* const thermistor_name_10 = "RS 198-961";
+#define THERMISTOR_NAME_10 thermistor_name_10
 
-#define THERMISTOR_NAME_11 "1% beta 3950"
+const char* const thermistor_name_11 = "1% beta 3950";
+#define THERMISTOR_NAME_11 thermistor_name_11
 
-#define THERMISTOR_NAME_12 "Unknown"
+const char* const thermistor_name_12 = "Unknown";
+#define THERMISTOR_NAME_12 thermistor_name_12
 
-#define THERMISTOR_NAME_501 "Unknown"
+const char* const thermistor_name_501 = "Unknown";
+#define THERMISTOR_NAME_501 thermistor_name_501
 
-#define THERMISTOR_NAME_15 "Unknown"
+const char* const thermistor_name_15 = "Unknown";
+#define THERMISTOR_NAME_15 thermistor_name_15
 
-#define THERMISTOR_NAME_55 "Unknown"
+const char* const thermistor_name_75 = "Unknown";
+#define THERMISTOR_NAME_75 thermistor_name_75
 
-#define THERMISTOR_NAME_75 "Unknown"
+const char* const thermistor_name_13 = "Hisens";
+#define THERMISTOR_NAME_13 thermistor_name_13
 
-#define THERMISTOR_NAME_13 "Hisens"
+const char* const thermistor_name_20 = "PT100 UltiMB";
+#define THERMISTOR_NAME_20 thermistor_name_20
 
-#define THERMISTOR_NAME_20 "PT100 UltiMB"
+const char* const thermistor_name_60 = "Makers Tool";
+#define THERMISTOR_NAME_60 thermistor_name_60
 
-#define THERMISTOR_NAME_60 "Makers Tool"
+const char* const thermistor_name_70 = "Hephestos 2";
+#define THERMISTOR_NAME_70 thermistor_name_70
 
-#define THERMISTOR_NAME_70 "Hephestos 2"
-
-#define THERMISTOR_NAME_80 "MGB18"
+const char* const thermistor_name_80 = "MGB18";
+#define THERMISTOR_NAME_80 thermistor_name_80
 
 // Modified thermistors
 
-#define THERMISTOR_NAME_51 "EPCOS 1K"
+const char* const thermistor_name_51 = "EPCOS 1K";
+#define THERMISTOR_NAME_51 thermistor_name_51
 
-#define THERMISTOR_NAME_52 "ATC204GT-2 1K"
+const char* const thermistor_name_52 = "ATC204GT-2 1K";
+#define THERMISTOR_NAME_52 thermistor_name_52
 
-#define THERMISTOR_NAME_55 "ATC104GT-2 1K"
+const char* const thermistor_name_55 = "ATC104GT-2 1K";
+#define THERMISTOR_NAME_55 thermistor_name_55
 
-#define THERMISTOR_NAME_1047 "PT1000 4K7"
+const char* const thermistor_name_1047 = "PT1000 4K7";
+#define THERMISTOR_NAME_1047 thermistor_name_1047
 
-#define THERMISTOR_NAME_1010 "PT1000 1K"
+const char* const thermistor_name_1010 = "PT1000 1K";
+#define THERMISTOR_NAME_1010 thermistor_name_1010
 
-#define THERMISTOR_NAME_147 "PT100 4K7"
+const char* const thermistor_name_147 = "PT100 4K7";
+#define THERMISTOR_NAME_147 thermistor_name_147
 
-#define THERMISTOR_NAME_110 "PT100 1K"
+const char* const thermistor_name_110 = "PT100 1K";
+#define THERMISTOR_NAME_110 thermistor_name_110
 
 // High Temperature thermistors
 
-#define THERMISTOR_NAME_66 "Dyze 4.7M"
+const char* const thermistor_name_66 = "Dyze 4.7M";
+#define THERMISTOR_NAME_66 thermistor_name_66
 
 // Dummies for dev testing
-#define THERMISTOR_NAME_998 "Dummy 1"
 
-#define THERMISTOR_NAME_999 "Dummy 2"
+const char* const thermistor_name_998 = "Dummy 1";
+#define THERMISTOR_NAME_998 thermistor_name_998
+
+const char* const thermistor_name_999 = "Dummy 2";
+#define THERMISTOR_NAME_999 thermistor_name_999

--- a/Marlin/thermistornames.h
+++ b/Marlin/thermistornames.h
@@ -97,3 +97,84 @@
   #define THERMISTOR_NAME "Dummy 2"
 
 #endif // THERMISTOR_ID
+
+// Thermcouples
+
+#define THERMISTOR_NAME_AD8495 "AD8495"
+
+#define THERMISTOR_NAME_MAX31855 "MAX31855"
+
+#define THERMISTOR_NAME_MAX6675 "MAX6675"
+
+#define THERMISTOR_NAME_AD595 "AD595"
+
+// Standard thermistors
+
+#define THERMISTOR_NAME_1 "EPCOS 100K"
+
+#define THERMISTOR_NAME_2 "ATC 204GT-2"
+
+#define THERMISTOR_NAME_3 "Mendel-parts"
+
+#define THERMISTOR_NAME_4 "Generic 10K"
+
+#define THERMISTOR_NAME_5 "ATC 104GT-2"
+
+#define THERMISTOR_NAME_6 "EPCOS (alt)"
+
+#define THERMISTOR_NAME_7 "Honeywell 104LAG"
+
+#define THERMISTOR_NAME_71 "Honeywell 104LAF"
+
+#define THERMISTOR_NAME_8 "E3104FHT"
+
+#define THERMISTOR_NAME_9 "GE AL03006"
+
+#define THERMISTOR_NAME_10 "RS 198-961"
+
+#define THERMISTOR_NAME_11 "1% beta 3950"
+
+#define THERMISTOR_NAME_12 "Unknown"
+
+#define THERMISTOR_NAME_501 "Unknown"
+
+#define THERMISTOR_NAME_15 "Unknown"
+
+#define THERMISTOR_NAME_55 "Unknown"
+
+#define THERMISTOR_NAME_75 "Unknown"
+
+#define THERMISTOR_NAME_13 "Hisens"
+
+#define THERMISTOR_NAME_20 "PT100 UltiMB"
+
+#define THERMISTOR_NAME_60 "Makers Tool"
+
+#define THERMISTOR_NAME_70 "Hephestos 2"
+
+#define THERMISTOR_NAME_80 "MGB18"
+
+// Modified thermistors
+
+#define THERMISTOR_NAME_51 "EPCOS 1K"
+
+#define THERMISTOR_NAME_52 "ATC204GT-2 1K"
+
+#define THERMISTOR_NAME_55 "ATC104GT-2 1K"
+
+#define THERMISTOR_NAME_1047 "PT1000 4K7"
+
+#define THERMISTOR_NAME_1010 "PT1000 1K"
+
+#define THERMISTOR_NAME_147 "PT100 4K7"
+
+#define THERMISTOR_NAME_110 "PT100 1K"
+
+// High Temperature thermistors
+
+#define THERMISTOR_NAME_66 "Dyze 4.7M"
+
+// Dummies for dev testing
+#define THERMISTOR_NAME_998 "Dummy 1"
+
+#define THERMISTOR_NAME_999 "Dummy 2"

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -180,6 +180,9 @@
 #ifdef THERMISTORCHAMBER
   #define CHAMBERTEMPTABLE TT_NAME(THERMISTORCHAMBER)
   #define CHAMBERTEMPTABLE_LEN COUNT(CHAMBERTEMPTABLE)
+    static void* chamberTempTable[1] = {(void*)CHAMBERTEMPTABLE};
+    static uint8_t chamberTempTableLen[1] = {COUNT(CHAMBERTEMPTABLE)};
+    static char *sensor_name_chamber = INIT_NAME(THERMISTORCHAMBER);
 #elif defined(HEATER_CHAMBER_USES_THERMISTOR)
   #error "No chamber thermistor table specified"
 #else

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -111,8 +111,7 @@
 #if THERMISTORHEATER_0
   #define HEATER_0_TEMPTABLE TT_NAME(THERMISTORHEATER_0)
   #define HEATER_0_TEMPTABLE_LEN COUNT(HEATER_0_TEMPTABLE)
-  //Current sensor name
-  static char *sensor_name_heater0 = INIT_NAME(THERMISTORHEATER_0);
+  #define HEATER_0_SENSOR_NAME INIT_NAME(THERMISTORHEATER_0)
 #elif defined(HEATER_0_USES_THERMISTOR)
   #error "No heater 0 thermistor table specified"
 #else
@@ -123,7 +122,7 @@
 #if THERMISTORHEATER_1
   #define HEATER_1_TEMPTABLE TT_NAME(THERMISTORHEATER_1)
   #define HEATER_1_TEMPTABLE_LEN COUNT(HEATER_1_TEMPTABLE)
-  static char *sensor_name_heater1 = INIT_NAME(THERMISTORHEATER_1);
+  #define HEATER_1_SENSOR_NAME INIT_NAME(THERMISTORHEATER_1)
 #elif defined(HEATER_1_USES_THERMISTOR)
   #error "No heater 1 thermistor table specified"
 #else
@@ -134,7 +133,7 @@
 #if THERMISTORHEATER_2
   #define HEATER_2_TEMPTABLE TT_NAME(THERMISTORHEATER_2)
   #define HEATER_2_TEMPTABLE_LEN COUNT(HEATER_2_TEMPTABLE)
-  static char *sensor_name_heater2 = INIT_NAME(THERMISTORHEATER_2);
+  #define HEATER_2_SENSOR_NAME INIT_NAME(THERMISTORHEATER_2)
 #elif defined(HEATER_2_USES_THERMISTOR)
   #error "No heater 2 thermistor table specified"
 #else
@@ -145,7 +144,7 @@
 #if THERMISTORHEATER_3
   #define HEATER_3_TEMPTABLE TT_NAME(THERMISTORHEATER_3)
   #define HEATER_3_TEMPTABLE_LEN COUNT(HEATER_3_TEMPTABLE)
-  static char *sensor_name_heater3 = INIT_NAME(THERMISTORHEATER_3);
+  #define HEATER_3_SENSOR_NAME INIT_NAME(THERMISTORHEATER_3)
 #elif defined(HEATER_3_USES_THERMISTOR)
   #error "No heater 3 thermistor table specified"
 #else
@@ -156,7 +155,7 @@
 #if THERMISTORHEATER_4
   #define HEATER_4_TEMPTABLE TT_NAME(THERMISTORHEATER_4)
   #define HEATER_4_TEMPTABLE_LEN COUNT(HEATER_4_TEMPTABLE)
-  static char *sensor_name_heater4 = INIT_NAME(THERMISTORHEATER_4);
+  #define HEATER_4_SENSOR_NAME INIT_NAME(THERMISTORHEATER_4)
 #elif defined(HEATER_4_USES_THERMISTOR)
   #error "No heater 4 thermistor table specified"
 #else
@@ -167,10 +166,7 @@
 #ifdef THERMISTORBED
   #define BEDTEMPTABLE TT_NAME(THERMISTORBED)
   #define BEDTEMPTABLE_LEN COUNT(BEDTEMPTABLE)
-  static void* bedTempTable[1] = {(void*)BEDTEMPTABLE};
-  static uint8_t bedTempTableLen[1] = {COUNT(BEDTEMPTABLE)};
-  static char *sensor_name_bed = INIT_NAME(THERMISTORBED);
-  
+  #define BED_SENSOR_NAME INIT_NAME(THERMISTORBED)
 #elif defined(HEATER_BED_USES_THERMISTOR)
   #error "No bed thermistor table specified"
 #else
@@ -180,9 +176,7 @@
 #ifdef THERMISTORCHAMBER
   #define CHAMBERTEMPTABLE TT_NAME(THERMISTORCHAMBER)
   #define CHAMBERTEMPTABLE_LEN COUNT(CHAMBERTEMPTABLE)
-    static void* chamberTempTable[1] = {(void*)CHAMBERTEMPTABLE};
-    static uint8_t chamberTempTableLen[1] = {COUNT(CHAMBERTEMPTABLE)};
-    static char *sensor_name_chamber = INIT_NAME(THERMISTORCHAMBER);
+  #define CHAMBER_SENSOR_NAME INIT_NAME(THERMISTORCHAMBER)
 #elif defined(HEATER_CHAMBER_USES_THERMISTOR)
   #error "No chamber thermistor table specified"
 #else

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -159,8 +159,8 @@
 #ifdef THERMISTORBED
   #define BEDTEMPTABLE TT_NAME(THERMISTORBED)
   #define BEDTEMPTABLE_LEN COUNT(BEDTEMPTABLE)
-  static void* bedTempTable = temptable_1;
-  static uint8_t bedTempTableLen = COUNT(&bedTempTable);
+  static void* bedTempTable[1] = {(void*)BEDTEMPTABLE};
+  static uint8_t bedTempTableLen[1] = {COUNT(BEDTEMPTABLE)};
   
 #elif defined(HEATER_BED_USES_THERMISTOR)
   #error "No bed thermistor table specified"

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -25,7 +25,7 @@
 
 #include "Marlin.h"
 #include "macros.h"
-
+#include "thermistornames.h"
 #define OVERSAMPLENR 16
 #define OV(N) int16_t((N)*(OVERSAMPLENR))
 
@@ -105,10 +105,14 @@
 
 #define _TT_NAME(_N) temptable_ ## _N
 #define TT_NAME(_N) _TT_NAME(_N)
+#define _INIT_NAME(_N) THERMISTOR_NAME_ ## _N
+#define INIT_NAME(_N) _INIT_NAME(_N)
 
 #if THERMISTORHEATER_0
   #define HEATER_0_TEMPTABLE TT_NAME(THERMISTORHEATER_0)
   #define HEATER_0_TEMPTABLE_LEN COUNT(HEATER_0_TEMPTABLE)
+  //Current sensor name
+  static char *sensor_name_heater0 = INIT_NAME(THERMISTORHEATER_0);
 #elif defined(HEATER_0_USES_THERMISTOR)
   #error "No heater 0 thermistor table specified"
 #else
@@ -119,6 +123,7 @@
 #if THERMISTORHEATER_1
   #define HEATER_1_TEMPTABLE TT_NAME(THERMISTORHEATER_1)
   #define HEATER_1_TEMPTABLE_LEN COUNT(HEATER_1_TEMPTABLE)
+  static char *sensor_name_heater1 = INIT_NAME(THERMISTORHEATER_1);
 #elif defined(HEATER_1_USES_THERMISTOR)
   #error "No heater 1 thermistor table specified"
 #else
@@ -129,6 +134,7 @@
 #if THERMISTORHEATER_2
   #define HEATER_2_TEMPTABLE TT_NAME(THERMISTORHEATER_2)
   #define HEATER_2_TEMPTABLE_LEN COUNT(HEATER_2_TEMPTABLE)
+  static char *sensor_name_heater2 = INIT_NAME(THERMISTORHEATER_2);
 #elif defined(HEATER_2_USES_THERMISTOR)
   #error "No heater 2 thermistor table specified"
 #else
@@ -139,6 +145,7 @@
 #if THERMISTORHEATER_3
   #define HEATER_3_TEMPTABLE TT_NAME(THERMISTORHEATER_3)
   #define HEATER_3_TEMPTABLE_LEN COUNT(HEATER_3_TEMPTABLE)
+  static char *sensor_name_heater3 = INIT_NAME(THERMISTORHEATER_3);
 #elif defined(HEATER_3_USES_THERMISTOR)
   #error "No heater 3 thermistor table specified"
 #else
@@ -149,6 +156,7 @@
 #if THERMISTORHEATER_4
   #define HEATER_4_TEMPTABLE TT_NAME(THERMISTORHEATER_4)
   #define HEATER_4_TEMPTABLE_LEN COUNT(HEATER_4_TEMPTABLE)
+  static char *sensor_name_heater4 = INIT_NAME(THERMISTORHEATER_4);
 #elif defined(HEATER_4_USES_THERMISTOR)
   #error "No heater 4 thermistor table specified"
 #else
@@ -161,6 +169,7 @@
   #define BEDTEMPTABLE_LEN COUNT(BEDTEMPTABLE)
   static void* bedTempTable[1] = {(void*)BEDTEMPTABLE};
   static uint8_t bedTempTableLen[1] = {COUNT(BEDTEMPTABLE)};
+  static char *sensor_name_bed = INIT_NAME(THERMISTORBED);
   
 #elif defined(HEATER_BED_USES_THERMISTOR)
   #error "No bed thermistor table specified"

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -41,96 +41,67 @@
 #define PtAdVal(T,R0,Rup) (short)(1024/(Rup/PtRt(T,R0)+1))
 #define PtLine(T,R0,Rup) { OV(PtAdVal(T,R0,Rup)), T },
 
-#if ANY_THERMISTOR_IS(1) // 100k bed thermistor
+
   #include "thermistortable_1.h"
-#endif
-#if ANY_THERMISTOR_IS(2) // 200k bed thermistor
+
   #include "thermistortable_2.h"
-#endif
-#if ANY_THERMISTOR_IS(3) // mendel-parts
+
   #include "thermistortable_3.h"
-#endif
-#if ANY_THERMISTOR_IS(4) // 10k thermistor
+
   #include "thermistortable_4.h"
-#endif
-#if ANY_THERMISTOR_IS(5) // 100k ParCan thermistor (104GT-2)
+
   #include "thermistortable_5.h"
-#endif
-#if ANY_THERMISTOR_IS(501) // 100k Zonestar thermistor
+
   #include "thermistortable_501.h"
-#endif
-#if ANY_THERMISTOR_IS(6) // 100k Epcos thermistor
+
   #include "thermistortable_6.h"
-#endif
-#if ANY_THERMISTOR_IS(7) // 100k Honeywell 135-104LAG-J01
+
   #include "thermistortable_7.h"
-#endif
-#if ANY_THERMISTOR_IS(71) // 100k Honeywell 135-104LAF-J01
+
   #include "thermistortable_71.h"
-#endif
-#if ANY_THERMISTOR_IS(8) // 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup)
+
   #include "thermistortable_8.h"
-#endif
-#if ANY_THERMISTOR_IS(9) // 100k GE Sensing AL03006-58.2K-97-G1 (4.7k pullup)
+
   #include "thermistortable_9.h"
-#endif
-#if ANY_THERMISTOR_IS(10) // 100k RS thermistor 198-961 (4.7k pullup)
+
   #include "thermistortable_10.h"
-#endif
-#if ANY_THERMISTOR_IS(11) // QU-BD silicone bed QWG-104F-3950 thermistor
+
   #include "thermistortable_11.h"
-#endif
-#if ANY_THERMISTOR_IS(13) // Hisens thermistor B25/50 =3950 +/-1%
+
   #include "thermistortable_13.h"
-#endif
-#if ANY_THERMISTOR_IS(15) // JGAurora A5 thermistor calibration
+
   #include "thermistortable_15.h"
-#endif
-#if ANY_THERMISTOR_IS(20) // PT100 with INA826 amp on Ultimaker v2.0 electronics
+
   #include "thermistortable_20.h"
-#endif
-#if ANY_THERMISTOR_IS(51) // 100k EPCOS (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
+
   #include "thermistortable_51.h"
-#endif
-#if ANY_THERMISTOR_IS(52) // 200k ATC Semitec 204GT-2 (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
+
   #include "thermistortable_52.h"
-#endif
-#if ANY_THERMISTOR_IS(55) // 100k ATC Semitec 104GT-2 (Used on ParCan) (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
+
   #include "thermistortable_55.h"
-#endif
-#if ANY_THERMISTOR_IS(60) // Maker's Tool Works Kapton Bed Thermistor
+
   #include "thermistortable_60.h"
-#endif
-#if ANY_THERMISTOR_IS(66) // DyzeDesign 500°C Thermistor
+
   #include "thermistortable_66.h"
-#endif
-#if ANY_THERMISTOR_IS(12) // 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup) (calibrated for Makibox hot bed)
+
   #include "thermistortable_12.h"
-#endif
-#if ANY_THERMISTOR_IS(70) // bqh2 stock thermistor
+
   #include "thermistortable_70.h"
-#endif
-#if ANY_THERMISTOR_IS(75) // Many of the generic silicon heat pads use the MGB18-104F39050L32 Thermistor
+
   #include "thermistortable_75.h"
-#endif
-#if ANY_THERMISTOR_IS(110) // Pt100 with 1k0 pullup
+
   #include "thermistortable_110.h"
-#endif
-#if ANY_THERMISTOR_IS(147) // Pt100 with 4k7 pullup
+
   #include "thermistortable_147.h"
-#endif
-#if ANY_THERMISTOR_IS(1010) // Pt1000 with 1k0 pullup
+
   #include "thermistortable_1010.h"
-#endif
-#if ANY_THERMISTOR_IS(1047) // Pt1000 with 4k7 pullup
+
   #include "thermistortable_1047.h"
-#endif
-#if ANY_THERMISTOR_IS(998) // User-defined table 1
+
   #include "thermistortable_998.h"
-#endif
-#if ANY_THERMISTOR_IS(999) // User-defined table 2
+
   #include "thermistortable_999.h"
-#endif
+
 
 #define _TT_NAME(_N) temptable_ ## _N
 #define TT_NAME(_N) _TT_NAME(_N)
@@ -188,6 +159,9 @@
 #ifdef THERMISTORBED
   #define BEDTEMPTABLE TT_NAME(THERMISTORBED)
   #define BEDTEMPTABLE_LEN COUNT(BEDTEMPTABLE)
+  static void* bedTempTable = temptable_1;
+  static uint8_t bedTempTableLen = COUNT(&bedTempTable);
+  
 #elif defined(HEATER_BED_USES_THERMISTOR)
   #error "No bed thermistor table specified"
 #else


### PR DESCRIPTION
Changelog:

- GCODE line counter improvement for resend and pause processes.
- Added Configuration Overlay feature, that permits to configure the printer parameters at runtime using GCODEs.
- Added retract distance control for the Z calibration process.
- Implemented Configuration Overlay parameters reporting to check them after configuring the firmware.
- Changed chamber fan PWM control to a simple On/Off control.
- Corrected a bug when a resend is requested but no response is given from host. Now, while the firmware is waiting for a resend, the maximum discarded characters are two times the serial receive buffer. If this amount of characters is discarded and the host still doesn't respond, it will send the resend message again.
- Improved priority commands detection during a print process, such as changing the print settings or light intensity.
- Implemented begin and end print commands.
- Now, the values of the print settings will be reported after updating them.
- Implemented two new commands (M156/M157) that permit to modify the target temperature values while the printer is busy or printing.
- Changed the Gcode queue maximum length from 4 G-codes to 24 G-codes.
- Improved the algorithm that calculates the bed deviation when bed a levelling process is made.