### PR TITLE
[ST-719] Fix G30 on Marlin to be used to probe the P. Surface wherever with T1

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6242,10 +6242,19 @@ void home_axis_from_code(bool x_c, bool y_c, bool z_c){
    *   E   Engage the probe for each probe (default 1)
    */
   inline void gcode_G30() {
+
+    #if defined(BCN3D_MOD)
+    const float xpos = parser.linearval('X', current_position[X_AXIS]),
+                ypos = parser.linearval('Y', current_position[Y_AXIS]);
+
+    #else
     const float xpos = parser.linearval('X', current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER),
                 ypos = parser.linearval('Y', current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER);
 
     if (!position_is_reachable_by_probe(xpos, ypos)) return;
+    #endif
+
+
 
     // Disable leveling so the planner won't mess with us
     #if HAS_LEVELING
@@ -7970,6 +7979,12 @@ inline void gcode_G290(){//BCN3D Bed leveling
 
 	#ifdef BCN3D_PRINT_SIMULATION
 	dwell(4000); // 4 seconds delays
+
+  SERIAL_PROTOCOLPGM("ScrewBed0: ");
+	MYSERIAL0.print(0, 6);
+	SERIAL_PROTOCOLPGM(" ScrewBed1: ");
+	MYSERIAL0.print(0, 6);
+	SERIAL_EOL();
 	return;
 	#endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7979,7 +7979,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 
 	#ifdef BCN3D_PRINT_SIMULATION
 	dwell(4000); // 4 seconds delays
-  SERIAL_PROTOCOLPGM("ScrewBed0: ");
+	SERIAL_PROTOCOLPGM("ScrewBed0: ");
 	MYSERIAL0.print(0, 6);
 	SERIAL_PROTOCOLPGM(" ScrewBed1: ");
 	MYSERIAL0.print(0, 6);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7979,7 +7979,6 @@ inline void gcode_G290(){//BCN3D Bed leveling
 
 	#ifdef BCN3D_PRINT_SIMULATION
 	dwell(4000); // 4 seconds delays
-
   SERIAL_PROTOCOLPGM("ScrewBed0: ");
 	MYSERIAL0.print(0, 6);
 	SERIAL_PROTOCOLPGM(" ScrewBed1: ");

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.7.0RC8"
+  #define SHORT_BUILD_VERSION "v0.7.1RC1"
 
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-06-18"
+  #define STRING_DISTRIBUTION_DATE "2020-07-08"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.7.1RC1"
+  #define SHORT_BUILD_VERSION "v0.7.0RC9"
 
   /**
    * Verbose version identifier which should contain a reference to the location


### PR DESCRIPTION
Change log:
- Fix G30 on Marlin to be used to probe the P. Surface wherever with T1.
- Also, in G290, it reports bed leveling values when it is on sim mode.