### PR TITLE
Release v0.8.1

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -438,7 +438,7 @@
  * heater. If your configuration is significantly different than this and you don't understand
  * the issues involved, don't use bed PID until someone else verifies that your hardware works.
  */
-#define PIDTEMPBED
+//#define PIDTEMPBED
 
 //#define BED_LIMIT_SWITCHING
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -52,7 +52,7 @@
 #endif
 
 #if DISABLED(PIDTEMPBED)
-  #define BED_CHECK_INTERVAL 5000 // ms between checks in bang-bang control
+  #define BED_CHECK_INTERVAL 2000 // ms between checks in bang-bang control
   #if ENABLED(BED_LIMIT_SWITCHING)
     #define BED_HYSTERESIS 2 // Only disable heating if T>target+BED_HYSTERESIS and enable heating if T>target-BED_HYSTERESIS
   #endif

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.8.1RC6"
+  #define SHORT_BUILD_VERSION "v0.8.1RC7"
 
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-10-30"
+  #define STRING_DISTRIBUTION_DATE "2020-11-05"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.8.0"
+  #define SHORT_BUILD_VERSION "v0.8.1RC6"
 
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -50,7 +50,7 @@
    * version was tagged.
    */
 
-  #define STRING_DISTRIBUTION_DATE "2020-10-09"
+  #define STRING_DISTRIBUTION_DATE "2020-10-30"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.


### PR DESCRIPTION
Release notes:

- Disabled PID control for the printing surface temperature control. The default bang-bang control system will be used instead. This will ensure that the power supply isn't stressed because of the PID's fast switching.
- Set Bang Bang bed temperature control check interval to 2 seconds.