### PR TITLE
[ST-973] - Search & change the #defines in Marlin in order to have an autocalibration system with the piezoelectric

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -806,16 +806,16 @@
  *      O-- FRONT --+
  *    (0,0)
  */
-#define X_PROBE_OFFSET_FROM_EXTRUDER 17  // X offset: -left  +right  [of the nozzle]
+#define X_PROBE_OFFSET_FROM_EXTRUDER 5  // X offset: -left  +right  [of the nozzle]
 #define Y_PROBE_OFFSET_FROM_EXTRUDER 22  // Y offset: -front +behind [the nozzle]
-#define Z_PROBE_OFFSET_FROM_EXTRUDER 4.8   // Z offset: -below +above  [the nozzle]
+#define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle]
 
 #define X_SIGMA_SECOND_PROBE_OFFSET_FROM_EXTRUDER	-13.4
 #define Y_SIGMA_SECOND_PROBE_OFFSET_FROM_EXTRUDER	22
 #define Z_SIGMA_SECOND_PROBE_OFFSET_FROM_EXTRUDER	0//2.90
 
 // Certain types of probes need to stay away from edges
-#define MIN_PROBE_EDGE -8
+#define MIN_PROBE_EDGE 20
 
 // X and Y axis travel speed (mm/m) between probes
 #define XY_PROBE_SPEED 8000
@@ -915,19 +915,19 @@
 // The size of the print bed
 
 
-#define X_BED_SIZE 420
-#define Y_BED_SIZE 300
+#define X_BED_SIZE 210
+#define Y_BED_SIZE 297
 
 
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 // Epsilon default values
-#define X_MIN_POS -53.5
+#define X_MIN_POS -47
 #define Y_MIN_POS -1
 #define Z_MIN_POS 0
 #define X_MAX_POS (X_BED_SIZE + 2) 
 #define Y_MAX_POS Y_BED_SIZE + 1
-#define Z_MAX_POS 400
+#define Z_MAX_POS 210
 
 /**
  * Software Endstops
@@ -1012,9 +1012,9 @@
  *   leveling in steps so you can manually adjust the Z height at each grid-point.
  *   With an LCD controller the process is guided step-by-step.
  */
-#define AUTO_BED_LEVELING_3POINT
+//#define AUTO_BED_LEVELING_3POINT
 //#define AUTO_BED_LEVELING_LINEAR
-//#define AUTO_BED_LEVELING_BILINEAR
+#define AUTO_BED_LEVELING_BILINEAR
 //#define AUTO_BED_LEVELING_UBL
 //#define MESH_BED_LEVELING
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1022,7 +1022,7 @@
  * Normally G28 leaves leveling disabled on completion. Enable
  * this option to have G28 restore the prior leveling state.
  */
-//#define RESTORE_LEVELING_AFTER_G28
+#define RESTORE_LEVELING_AFTER_G28
 
 /**
  * Enable detailed logging of G28, G29, M48, etc.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6273,6 +6273,13 @@ void home_axis_from_code(bool x_c, bool y_c, bool z_c){
       SERIAL_PROTOCOLLNPAIR_F(" Z: ", measured_z);
     }
 
+    #if defined(BCN3D_MOD)
+    if (parser.boolval('S', true)) {
+      hotend_offset[Z_AXIS][active_extruder] = measured_z;
+      SERIAL_PROTOCOLLNPAIR_F("T1 offset Z: ", measured_z);
+    }
+    #endif
+
     clean_up_after_endstop_or_probe_move();
 
     #ifdef Z_AFTER_PROBING

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8008,7 +8008,8 @@ inline void gcode_G242(){//BCN3D Calib pattern for Y axis
 }
 
 inline void gcode_G290(){//BCN3D Bed leveling
-
+#ifdef AUTO_BED_LEVELING_BILINEAR
+#else
 	#ifdef BCN3D_PRINT_SIMULATION
 	dwell(4000); // 4 seconds delays
 	SERIAL_PROTOCOLPGM("ScrewBed0: ");
@@ -8218,6 +8219,7 @@ inline void gcode_G290(){//BCN3D Bed leveling
 	SERIAL_PROTOCOLPGM(" ScrewBed1: ");
 	MYSERIAL0.print(Z_knob_right-Z_knob_back, 6);
 	SERIAL_EOL();
+  #endif
 }
 
 inline void gcode_M668() {


### PR DESCRIPTION
Changelog:

- Change the #defines in order to have an autocalibration with a mounted zprobe