### PR TITLE
[ST-1152] T1 Z offset is accumulated instead of being reset when a calib. is done

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6258,6 +6258,12 @@ void home_axis_from_code(bool x_c, bool y_c, bool z_c){
    *   E   Engage the probe for each probe (default 1)
    */
   inline void gcode_G30() {
+    #if defined(BCN3D_MOD)
+    if (parser.boolval('S', true)) {
+      hotend_offset[Z_AXIS][active_extruder] = 0; //Reset hotend offset, this way we don't take the current one into account.
+    }
+    #endif
+    
 
     #if defined(BCN3D_MOD)
     const float xpos = parser.linearval('X', current_position[X_AXIS]),

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -36,7 +36,7 @@
    * Marlin release version identifier
    */
 
-  #define SHORT_BUILD_VERSION "v0.9.0"
+  #define SHORT_BUILD_VERSION "v0.9.2RC22"
 
   /**
    * Verbose version identifier which should contain a reference to the location


### PR DESCRIPTION
link: https://bcn3d.atlassian.net/browse/ST-1152
Changelog:

- T1 offset set to 0 before T1 calibration